### PR TITLE
Add preview rows adapter and tests

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -397,7 +397,12 @@ async def cb_preview(call: types.CallbackQuery):
 
     try:
         rows = await parser_adapter.preview_rows(
-            title, city, area_id=area_id, include=include, exclude=exclude
+            uid,
+            title,
+            city,
+            area=area_id,
+            include=include,
+            exclude=exclude,
         )
     except Exception:
         logging.exception("preview failed")

--- a/tests/test_preview_rows.py
+++ b/tests/test_preview_rows.py
@@ -1,0 +1,39 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services import parser_adapter
+
+
+def test_preview_rows_converts_to_dict(monkeypatch):
+    async def fake_preview_report(*args, **kwargs):
+        return [("Dev", "Acme", "https://hh.ru/vacancy/1")]
+
+    monkeypatch.setattr(parser_adapter, "preview_report", fake_preview_report)
+
+    rows = asyncio.run(parser_adapter.preview_rows(123, "Dev", "Москва"))
+
+    assert isinstance(rows, list)
+    assert rows == [
+        {
+            "title": "Dev",
+            "company": "Acme",
+            "salary": "",
+            "link": "https://hh.ru/vacancy/1",
+        }
+    ]
+
+
+def test_preview_rows_handles_empty(monkeypatch):
+    async def fake_preview_report(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(parser_adapter, "preview_report", fake_preview_report)
+
+    rows = asyncio.run(parser_adapter.preview_rows(1, "", ""))
+
+    assert rows == []


### PR DESCRIPTION
## Summary
- add an async `preview_rows` adapter that normalises preview data for the handler
- update the preview callback to work with the new dictionary-based payload
- cover the new adapter with unit tests to avoid regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cabb104d788320a0e69dcc974447c7