### PR TITLE
Fix YooKassa idempotency key name

### DIFF
--- a/app/services/payments.py
+++ b/app/services/payments.py
@@ -91,7 +91,7 @@ def create_payment(user_id: int, pack: str, bot_username: str | None = None) -> 
         },
         # Чек (фискализация) опускаем в MVP — зависит от настроек магазина
     }
-    p = Payment.create(body, idempotence_key=idem)
+    p = Payment.create(body, idempotency_key=idem)
     # Сохраним pending в нашей БД
     payment = repo.create_payment(user_id, pack, amount_cop, "RUB", payload=p.id)
     log.info("YooKassa create: id=%s pack=%s amount=%s", p.id, pack, amount_cop)


### PR DESCRIPTION
## Summary
- update the YooKassa Payment.create call to pass the idempotency key with the correct parameter name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac71ae4a88320a5e80b4b8e67d565