### PR TITLE
Reset search state on /start

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -19,7 +19,13 @@ def _is_admin(user_id: int) -> bool:
 
 
 # ---------- /start ----------
-async def cmd_start(message: types.Message):
+async def cmd_start(message: types.Message, state: FSMContext):
+    try:
+        await state.finish()
+    except Exception:
+        # на случай, если состояния нет или не инициализировано
+        pass
+
     kb = keyboards.main_kb(is_admin=_is_admin(message.from_user.id))
 
     # 1) Пробуем отправить баннер (если файл есть) с коротким капшеном


### PR DESCRIPTION
## Summary
- reset the ongoing search dialog state when /start is invoked so the user returns to the main menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad0cd009c8320abc6c2a6d7f28562