### PR TITLE
Align HH search field usage between validator and pipeline

### DIFF
--- a/app/services/validator.py
+++ b/app/services/validator.py
@@ -4,6 +4,8 @@ import re
 from typing import Optional, Tuple, List
 import requests
 
+from vendor.parser_tdnm.constants import DEFAULT_HH_SEARCH_FIELD
+
 UA = os.getenv("PARSER_USER_AGENT", "hr-assist/1.0")
 HH_BASE = os.getenv("PARSER_HH_BASE", "https://api.hh.ru")
 REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
@@ -85,7 +87,12 @@ def probe_hh_found(title: str, area_id: int) -> Tuple[bool, int]:
     try:
         r = requests.get(
             f"{HH_BASE}/vacancies",
-            params={"text": t, "area": area_id, "per_page": 1},
+            params={
+                "text": t,
+                "area": area_id,
+                "per_page": 1,
+                "search_field": DEFAULT_HH_SEARCH_FIELD,
+            },
             headers={"User-Agent": UA},
             timeout=REQUEST_TIMEOUT,
         )

--- a/vendor/parser_tdnm/constants.py
+++ b/vendor/parser_tdnm/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for the TDNM vacancy parser and related services."""
+
+DEFAULT_HH_SEARCH_FIELD = "name"
+

--- a/vendor/parser_tdnm/parsers/fetch_vacancies.py
+++ b/vendor/parser_tdnm/parsers/fetch_vacancies.py
@@ -2,6 +2,8 @@
 import time, argparse, pandas as pd, re, urllib.parse, html
 from typing import List, Dict, Any, Tuple, Optional
 
+from ..constants import DEFAULT_HH_SEARCH_FIELD
+
 try:  # pragma: no cover - зависимость должна ставиться вместе с ботом
     import requests
 except ImportError:  # pragma: no cover
@@ -484,7 +486,7 @@ def main():
     ap.add_argument("--per-page", dest="per_page", type=int, default=50)
     ap.add_argument("--per_page", dest="per_page", type=int, help="alias", metavar="N")
     ap.add_argument("--pause", type=float, default=0.6)
-    ap.add_argument("--search-in", dest="search_in", default="name",
+    ap.add_argument("--search-in", dest="search_in", default=DEFAULT_HH_SEARCH_FIELD,
                     help="name|description|company_name|everything")
     ap.add_argument("--search_in", dest="search_in", help="alias")
     ap.add_argument("--site", choices=["hh", "gorodrabot", "both"], default="both")

--- a/vendor/parser_tdnm/run_pipeline.py
+++ b/vendor/parser_tdnm/run_pipeline.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List
 
+from .constants import DEFAULT_HH_SEARCH_FIELD
+
 ROOT = Path(__file__).resolve().parent
 PARSERS_DIR = ROOT / "parsers"
 DEFAULT_OUTPUT_DIR = ROOT / "exports"
@@ -38,7 +40,7 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
                         help="Пауза между запросами к HH")
     parser.add_argument("--site", choices=["hh", "gorodrabot", "both"], default="hh",
                         help="Ограничить источники вакансий")
-    parser.add_argument("--search-in", dest="search_in", default="name",
+    parser.add_argument("--search-in", dest="search_in", default=DEFAULT_HH_SEARCH_FIELD,
                         choices=["name", "description", "company_name", "everything"],
                         help="Поле поиска HH")
     parser.add_argument("--search_in", dest="search_in", help="alias")


### PR DESCRIPTION
## Summary
- add a shared DEFAULT_HH_SEARCH_FIELD constant for HH integrations
- ensure the pipeline CLI and validator use the shared search_field value when calling HH

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cba6b80a388320893011e3cd0a7640