### PR TITLE
Fix run_pipeline import when executed as script

### DIFF
--- a/vendor/parser_tdnm/run_pipeline.py
+++ b/vendor/parser_tdnm/run_pipeline.py
@@ -14,7 +14,15 @@ import sys
 from pathlib import Path
 from typing import Iterable, List
 
-from .constants import DEFAULT_HH_SEARCH_FIELD
+try:  # pragma: no cover - import shim for script execution
+    from .constants import DEFAULT_HH_SEARCH_FIELD
+except ImportError:  # noqa: F401 - fallback for running as standalone script
+    import importlib
+
+    current_dir = Path(__file__).resolve().parent
+    if str(current_dir) not in sys.path:
+        sys.path.insert(0, str(current_dir))
+    DEFAULT_HH_SEARCH_FIELD = importlib.import_module("constants").DEFAULT_HH_SEARCH_FIELD
 
 ROOT = Path(__file__).resolve().parent
 PARSERS_DIR = ROOT / "parsers"


### PR DESCRIPTION
## Summary
- add an import shim in run_pipeline so constants can be loaded when the script is executed directly

## Testing
- python vendor/parser_tdnm/run_pipeline.py --help

------
https://chatgpt.com/codex/tasks/task_e_68cba8707594832099893924b4ce8819