### PR TITLE
Handle standalone import of parser constants

### DIFF
--- a/vendor/parser_tdnm/parsers/fetch_vacancies.py
+++ b/vendor/parser_tdnm/parsers/fetch_vacancies.py
@@ -2,7 +2,17 @@
 import time, argparse, pandas as pd, re, urllib.parse, html
 from typing import List, Dict, Any, Tuple, Optional
 
-from ..constants import DEFAULT_HH_SEARCH_FIELD
+try:  # pragma: no cover - import shim for script execution
+    from ..constants import DEFAULT_HH_SEARCH_FIELD
+except ImportError:  # noqa: F401 - fallback for running as standalone script
+    import importlib
+    import sys
+    from pathlib import Path
+
+    current_dir = Path(__file__).resolve().parent.parent
+    if str(current_dir) not in sys.path:
+        sys.path.insert(0, str(current_dir))
+    DEFAULT_HH_SEARCH_FIELD = importlib.import_module("constants").DEFAULT_HH_SEARCH_FIELD
 
 try:  # pragma: no cover - зависимость должна ставиться вместе с ботом
     import requests


### PR DESCRIPTION
## Summary
- add a standalone execution fallback for importing `DEFAULT_HH_SEARCH_FIELD` in the vacancy fetcher

## Testing
- `python vendor/parser_tdnm/run_pipeline.py --query "повар" --pages 1 --per-page 1 --site hh --formats csv` *(fails: pandas not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbab5d78ec8320b0668193d8a2b5a2