### PR TITLE
Show main menu after reports and share admin helper

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import os
 import asyncio
 from datetime import datetime
 from typing import List, Tuple
@@ -12,10 +11,10 @@ from pathlib import Path
 from app.storage import repo
 from app.storage.models import User
 from app.utils.backup import make_sqlite_backup
+from app.utils.admins import is_admin
 
 # --- доступ ---
-ADMINS = {int(x) for x in os.getenv("ADMIN_USER_IDS", "").replace(" ", "").split(",") if x.isdigit()}
-def _guard(uid: int) -> bool: return uid in ADMINS
+def _guard(uid: int) -> bool: return is_admin(uid)
 
 # --- пагинация ---
 PAGE_SIZE = 10

--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -20,6 +20,8 @@ from ..middlewares.busy import is_busy, set_busy, clear_busy, BUSY_TEXT
 from ..services import parser_adapter
 from ..services import validator  # валидация запроса
 from ..services.quota import check_and_consume
+from app import keyboards
+from app.utils.admins import is_admin
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +45,10 @@ async def _ensure_quota(
 
     decision = check_and_consume(uid, username, full_name)
     if not decision.allowed:
-        await message.answer(decision.message or "Лимит исчерпан — попробуйте позже 🙏")
+        await message.answer(
+            decision.message or "Лимит исчерпан — попробуйте позже 🙏",
+            reply_markup=_main_menu_kb(message, user=user),
+        )
         return False
 
     if decision.mode == "paid":
@@ -108,6 +113,12 @@ def _resolve_requester_id(message: types.Message, uid: int | None = None) -> int
     raise ValueError("Cannot determine requester id")
 
 
+def _main_menu_kb(message: types.Message, *, user: types.User | None = None):
+    person = user or getattr(message, "from_user", None)
+    user_id = getattr(person, "id", None)
+    return keyboards.main_kb(is_admin=is_admin(user_id))
+
+
 async def _run_parser_bypass_validation(
     message: types.Message,
     query: str,
@@ -136,15 +147,15 @@ async def _run_parser_bypass_validation(
     except Exception as e:  # pragma: no cover
         logging.exception("parser failed")
         err_text = (str(e) or "").strip() or "Не удалось получить отчёт: парсер вернул ошибку. Попробуйте позже"
-        await message.answer(err_text)
+        await message.answer(err_text, reply_markup=_main_menu_kb(message, user=user))
         return
     finally:
         clear_busy(uid)
 
     if path.exists():
-        await message.answer_document(InputFile(path))
+        await message.answer_document(InputFile(path), reply_markup=_main_menu_kb(message, user=user))
     else:
-        await message.answer("Отчёт не найден. Проверьте логи.")
+        await message.answer("Отчёт не найден. Проверьте логи.", reply_markup=_main_menu_kb(message, user=user))
 
 
 async def _run_with_amount(
@@ -198,15 +209,15 @@ async def _run_with_amount(
     except Exception as e:
         logging.exception("parser failed")
         err_text = (str(e) or "").strip() or "Не удалось получить отчёт: парсер вернул ошибку. Попробуйте позже"
-        await message.answer(err_text)
+        await message.answer(err_text, reply_markup=_main_menu_kb(message, user=user))
         return
     finally:
         clear_busy(uid)
 
     if path.exists():
-        await message.answer_document(InputFile(path))
+        await message.answer_document(InputFile(path), reply_markup=_main_menu_kb(message, user=user))
     else:
-        await message.answer("Отчёт не найден. Проверьте логи.")
+        await message.answer("Отчёт не найден. Проверьте логи.", reply_markup=_main_menu_kb(message, user=user))
 
 
 # ---------- core ----------
@@ -264,15 +275,15 @@ async def _run_parser(
         except Exception as e:
             logging.exception("parser failed")
             err_text = (str(e) or "").strip() or "Не удалось получить отчёт: парсер вернул ошибку. Попробуйте позже"
-            await message.answer(err_text)
+            await message.answer(err_text, reply_markup=_main_menu_kb(message, user=user))
             return
         finally:
             clear_busy(requester_id)
 
         if path.exists():
-            await message.answer_document(InputFile(path))
+            await message.answer_document(InputFile(path), reply_markup=_main_menu_kb(message, user=user))
         else:
-            await message.answer("Отчёт не найден. Проверьте логи.")
+            await message.answer("Отчёт не найден. Проверьте логи.", reply_markup=_main_menu_kb(message, user=user))
         return
 
     # 3) Шаг выбора объёма (число найденных НЕ показываем)

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -4,18 +4,14 @@ from aiogram import types, Dispatcher
 from aiogram.types import InputFile  # <- для баннера
 from app import keyboards
 from aiogram.dispatcher import FSMContext
+from app.utils.admins import is_admin
 
 
 # Админы и лимиты
-ADMINS = {int(x) for x in os.getenv("ADMIN_USER_IDS", "").replace(" ", "").split(",") if x.isdigit()}
 FREE_PER_MONTH = int(os.getenv("FREE_PER_MONTH", "3"))
 
 # Путь к баннеру (можно переопределить в .env: START_BANNER_PATH=assets/start_banner_1x1.png)
 BANNER_PATH = os.getenv("START_BANNER_PATH", "assets/start_banner_1x1.png")
-
-
-def _is_admin(user_id: int) -> bool:
-    return user_id in ADMINS
 
 
 # ---------- /start ----------
@@ -26,7 +22,7 @@ async def cmd_start(message: types.Message, state: FSMContext):
         # на случай, если состояния нет или не инициализировано
         pass
 
-    kb = keyboards.main_kb(is_admin=_is_admin(message.from_user.id))
+    kb = keyboards.main_kb(is_admin=is_admin(message.from_user.id))
 
     # 1) Пробуем отправить баннер (если файл есть) с коротким капшеном
     try:
@@ -99,13 +95,13 @@ async def cmd_advanced(message: types.Message):
 
 # -------- показать меню по слову «Меню» --------
 async def show_menu(message: types.Message):
-    kb = keyboards.main_kb(is_admin=_is_admin(message.from_user.id))
+    kb = keyboards.main_kb(is_admin=is_admin(message.from_user.id))
     await message.reply("Меню 👇", reply_markup=kb)
 
 # опционально /cancel — сбросить текущий диалог
 async def cmd_cancel(message: types.Message, state: FSMContext):
     await state.finish()
-    kb = keyboards.main_kb(is_admin=_is_admin(message.from_user.id))
+    kb = keyboards.main_kb(is_admin=is_admin(message.from_user.id))
     await message.reply("Окей, сбросил диалог. Нажми кнопки ниже или /start.", reply_markup=kb)
 
 def register(dp: Dispatcher):

--- a/app/utils/admins.py
+++ b/app/utils/admins.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable, Set
+
+
+def _load_admins() -> Set[int]:
+    raw = os.getenv("ADMIN_USER_IDS", "")
+    cleaned = raw.replace(" ", "")
+    return {int(x) for x in cleaned.split(",") if x.isdigit()}
+
+
+_ADMINS = _load_admins()
+
+
+def is_admin(user_id: int | None) -> bool:
+    """Return True if the given Telegram user id is an admin."""
+    if user_id is None:
+        return False
+    return user_id in _ADMINS
+
+
+def admin_ids() -> Iterable[int]:
+    """Expose the configured admin ids (read-only copy)."""
+    return set(_ADMINS)


### PR DESCRIPTION
## Summary
- add a shared admin helper module and reuse it in start and admin handlers
- ensure parser flows send the main menu keyboard after delivering reports or final messages
- surface the main menu when quota checks fail so users can continue without /start

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbae80c03883209750e5c81f529375