### PR TITLE
Add openpyxl dependency for Excel analytics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ python-dotenv==1.0.1
 requests==2.32.3
 pandas==2.2.2
 numpy==1.26.4
+openpyxl==3.1.5
 python-docx==1.1.2
 beautifulsoup4==4.12.3
 lxml==5.2.2


### PR DESCRIPTION
## Summary
- add the openpyxl dependency so pandas can read XLSX files for mini-analytics output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbd0814e108320a5819bb13edf0264