### PR TITLE
feat: add referral system

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,9 +18,21 @@ class Settings:
     PARSER_GORODRABOT_BASE: str | None = None
     HTTP_PROXY: str | None = None
     REQUEST_TIMEOUT: int | None = None
+    REF_ENABLED: bool = True
+    REF_BONUS_INVITEE: int = 0
+    REF_BONUS_INVITER: int = 0
+    REF_ATTRIBUTION_TTL_HOURS: int = 48
+    REF_MAX_BONUS_PER_DAY: int = 5
+    REF_MAX_BONUS_TOTAL: int = 100
+    REF_PROMO_TTL_HOURS: int = 48
 
 
 def _load() -> Settings:
+    def _bool(value: str | None, default: bool = False) -> bool:
+        if value is None:
+            return default
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
     cfg = Settings(
         TELEGRAM_BOT_TOKEN=os.getenv("TELEGRAM_BOT_TOKEN", ""),
         MODE=os.getenv("MODE", "polling"),
@@ -33,6 +45,13 @@ def _load() -> Settings:
         PARSER_GORODRABOT_BASE=os.getenv("PARSER_GORODRABOT_BASE"),
         HTTP_PROXY=os.getenv("HTTP_PROXY"),
         REQUEST_TIMEOUT=int(os.getenv("REQUEST_TIMEOUT", "20")),
+        REF_ENABLED=_bool(os.getenv("REF_ENABLED"), True),
+        REF_BONUS_INVITEE=int(os.getenv("REF_BONUS_INVITEE", "1")),
+        REF_BONUS_INVITER=int(os.getenv("REF_BONUS_INVITER", "1")),
+        REF_ATTRIBUTION_TTL_HOURS=int(os.getenv("REF_ATTRIBUTION_TTL_HOURS", "48")),
+        REF_MAX_BONUS_PER_DAY=int(os.getenv("REF_MAX_BONUS_PER_DAY", "5")),
+        REF_MAX_BONUS_TOTAL=int(os.getenv("REF_MAX_BONUS_TOTAL", "100")),
+        REF_PROMO_TTL_HOURS=int(os.getenv("REF_PROMO_TTL_HOURS", "48")),
     )
     if cfg.MODE not in {"polling", "webhook"}:
         raise ValueError("MODE must be 'polling' or 'webhook'")

--- a/app/handlers/referrals.py
+++ b/app/handlers/referrals.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import quote_plus
+
+from aiogram import Dispatcher, types
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from app.config import settings
+from app.services import referrals
+from app.storage import repo
+from app.utils.logging import log_event, update_context
+
+
+def _kb_referrals(link: str) -> InlineKeyboardMarkup:
+    share_text = quote_plus("HR-Assist — мой бот для вакансий. Держи ссылку: ")
+    share_url = f"https://t.me/share/url?url={quote_plus(link)}&text={share_text}"
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(InlineKeyboardButton("📋 Скопировать", callback_data="ref_copy"))
+    kb.add(InlineKeyboardButton("📤 Поделиться", url=share_url))
+    return kb
+
+
+async def cmd_referrals(message: types.Message):
+    update_context(command="/referrals")
+    log_event("request_parsed", message="/referrals", command="/referrals")
+    me = await message.bot.get_me()
+    link = referrals.build_referral_link(me.username or "", message.from_user.id)
+    stats = referrals.get_user_stats(message.from_user.id)
+    rules = referrals.render_rules_text()
+    text = (
+        f"{rules}\n\n"
+        f"Твоя ссылка: <code>{link}</code>\n"
+        f"Приглашено: {stats['invited']}\n"
+        f"Активировано: {stats['activated']}\n"
+        f"Получено бонусов: {stats['bonuses']}"
+    )
+    update_context(referral={"link": link, "stats": stats})
+    await message.reply(text, reply_markup=_kb_referrals(link))
+
+
+async def cb_ref_copy(call: types.CallbackQuery):
+    me = await call.bot.get_me()
+    link = referrals.build_referral_link(me.username or "", call.from_user.id)
+    await call.answer(link, show_alert=True)
+
+
+async def cmd_promo(message: types.Message):
+    update_context(command="/promo")
+    log_event("request_parsed", message="/promo", command="/promo")
+    code = (message.get_args() or "").strip()
+    if not code:
+        await message.reply("Введите промокод: /promo REF-XXXX")
+        return
+
+    user = repo.get_user(message.from_user.id)
+    if not user:
+        repo.ensure_user(message.from_user.id, message.from_user.username, message.from_user.full_name)
+        user = repo.get_user(message.from_user.id)
+    is_new = False
+    if user:
+        age_hours = (datetime.utcnow() - user.created_at).total_seconds() / 3600
+        is_new = age_hours <= settings.REF_PROMO_TTL_HOURS
+    ok, text = referrals.apply_promocode(message.from_user.id, code, is_new=is_new)
+    await message.reply(text)
+
+
+async def cmd_rewards(message: types.Message):
+    update_context(command="/rewards")
+    log_event("request_parsed", message="/rewards", command="/rewards")
+    entries = referrals.list_recent_rewards(message.from_user.id, limit=10)
+    lines = ["Последние начисления:"]
+    empty = True
+    for entry in entries:
+        empty = False
+        sign = "+" if entry.delta >= 0 else ""
+        ts = entry.ts.strftime("%Y-%m-%d %H:%M")
+        lines.append(f"{ts} — {sign}{entry.delta} ({entry.reason})")
+    if empty:
+        lines.append("Пока начислений нет.")
+    await message.reply("\n".join(lines))
+
+
+def register(dp: Dispatcher) -> None:
+    dp.register_message_handler(cmd_referrals, commands=["referrals"])
+    dp.register_message_handler(cmd_referrals, lambda m: (m.text or "").strip() in {"🎁 Рефералы", "Рефералы"}, state="*")
+    dp.register_callback_query_handler(cb_ref_copy, lambda c: c.data == "ref_copy")
+    dp.register_message_handler(cmd_promo, commands=["promo"])
+    dp.register_message_handler(cmd_rewards, commands=["rewards"])
+    dp.register_message_handler(cmd_rewards, lambda m: (m.text or "").strip() in {"🏆 Начисления", "Начисления"}, state="*")

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -4,6 +4,7 @@ def main_kb(is_admin: bool = False) -> ReplyKeyboardMarkup:
     kb = ReplyKeyboardMarkup(resize_keyboard=True)
     kb.row(KeyboardButton("🔎 Поиск"), KeyboardButton("🧭 Статус"))
     kb.row(KeyboardButton("💳 Купить"), KeyboardButton("ℹ️ Помощь"))
+    kb.row(KeyboardButton("🎁 Рефералы"), KeyboardButton("🏆 Начисления"))
     if is_admin:
         kb.add(KeyboardButton("🛠 Админ"))
     return kb

--- a/app/run.py
+++ b/app/run.py
@@ -15,6 +15,7 @@ from .handlers import (
     admin as h_admin,
     parse,
     payments as h_payments,
+    referrals as h_referrals,
     start,
     status,
 )
@@ -55,6 +56,7 @@ def create_dispatcher() -> Dispatcher:
     status.register(dp)
     parse.register(dp)
     h_payments.register(dp)
+    h_referrals.register(dp)
     h_admin.register(dp)
 
     async def _error_handler(update, error):  # noqa: ANN001

--- a/app/services/referrals.py
+++ b/app/services/referrals.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+from app.config import settings
+from app.storage import repo
+from app.storage import referrals_repo
+from app.storage.models import Referral
+from app.utils.logging import log_event, update_context
+
+
+@dataclass
+class StartResult:
+    inviter_id: Optional[int] = None
+    inviter_username: Optional[str] = None
+    status: str = "none"
+    message: Optional[str] = None
+    invitee_bonus: int = 0
+
+
+@dataclass
+class ActivationResult:
+    inviter_id: Optional[int] = None
+    inviter_username: Optional[str] = None
+    granted: bool = False
+    bonus: int = 0
+    reason: Optional[str] = None
+
+
+def _normalize_payload(payload: str) -> str:
+    return (payload or "").strip()
+
+
+def _build_referral_dict(referral: Referral | None, **extra) -> dict:
+    data = dict(extra)
+    if referral:
+        data.update(
+            {
+                "referral_id": referral.id,
+                "inviter_id": referral.inviter_id,
+                "invitee_id": referral.invitee_id,
+                "status": referral.status,
+                "source": referral.source,
+            }
+        )
+    return data
+
+
+def handle_start(
+    invitee_id: int,
+    payload: str,
+    *,
+    is_new: bool,
+    username: Optional[str],
+    full_name: Optional[str],
+) -> StartResult:
+    payload = _normalize_payload(payload)
+    if not settings.REF_ENABLED:
+        return StartResult(status="disabled")
+
+    if not payload.startswith("ref_"):
+        return StartResult(status="none")
+
+    token = payload.replace("ref_", "", 1)
+    stats = referrals_repo.find_referral_by_token(token)
+    if not stats:
+        log_event(
+            "referral_rejected",
+            level="WARN",
+            reason="invalid_token",
+            inviter_token=token,
+            invitee_id=invitee_id,
+        )
+        return StartResult(status="rejected", message="Реферальная ссылка недействительна.")
+    log_event(
+        "referral_link_opened",
+        inviter_id=stats.user_id,
+        invitee_id=invitee_id,
+        token=token,
+    )
+
+    inviter_id = stats.user_id
+    if inviter_id == invitee_id:
+        log_event(
+            "referral_rejected",
+            level="WARN",
+            reason="self_ref",
+            inviter_id=inviter_id,
+            invitee_id=invitee_id,
+        )
+        return StartResult(status="rejected", message="Нельзя пригласить самого себя 🙃")
+
+    if referrals_repo.is_banned(inviter_id) or referrals_repo.is_banned(invitee_id):
+        log_event(
+            "referral_rejected",
+            level="WARN",
+            reason="banned",
+            inviter_id=inviter_id,
+            invitee_id=invitee_id,
+        )
+        return StartResult(status="rejected", message="Реферальная программа недоступна для этой пары пользователей.")
+
+    existing = referrals_repo.get_referral_by_invitee(invitee_id)
+    if existing:
+        if existing.inviter_id == inviter_id:
+            inviter_user = repo.get_user(inviter_id)
+            return StartResult(
+                inviter_id=inviter_id,
+                inviter_username=_format_username(getattr(inviter_user, "username", None)),
+                status=existing.status,
+            )
+        log_event(
+            "referral_rejected",
+            level="WARN",
+            reason="duplicate",
+            inviter_id=inviter_id,
+            invitee_id=invitee_id,
+            prev_inviter=existing.inviter_id,
+        )
+        return StartResult(status="rejected", message="Промокод уже был использован ранее.")
+
+    if not is_new:
+        log_event(
+            "referral_rejected",
+            level="WARN",
+            reason="not_new",
+            inviter_id=inviter_id,
+            invitee_id=invitee_id,
+        )
+        return StartResult(status="rejected", message="Реферальная ссылка доступна только новым пользователям.")
+
+    ttl_hours = max(1, settings.REF_ATTRIBUTION_TTL_HOURS)
+    expires_at = datetime.utcnow() + timedelta(hours=ttl_hours)
+
+    referral = referrals_repo.create_referral(
+        inviter_id,
+        invitee_id,
+        token=token,
+        source="deep_link",
+        expires_at=expires_at,
+    )
+    update_context(referral=_build_referral_dict(referral))
+    log_event(
+        "referral_attributed",
+        inviter_id=inviter_id,
+        invitee_id=invitee_id,
+        expires_at=str(expires_at),
+    )
+
+    invitee_bonus = 0
+    if settings.REF_BONUS_INVITEE > 0:
+        invitee_bonus = settings.REF_BONUS_INVITEE
+        balance = referrals_repo.grant_credit(invitee_id, invitee_bonus, "referral_invitee", referral)
+        update_context(credits_delta=invitee_bonus)
+        log_event(
+            "bonus_granted",
+            user_id=invitee_id,
+            amount=invitee_bonus,
+            reason="referral_invitee",
+            balance=balance,
+        )
+
+    inviter = repo.get_user(inviter_id)
+    username_formatted = _format_username(getattr(inviter, "username", None))
+    return StartResult(
+        inviter_id=inviter_id,
+        inviter_username=username_formatted,
+        status="pending",
+        invitee_bonus=invitee_bonus,
+    )
+
+
+def _format_username(username: Optional[str]) -> Optional[str]:
+    if not username:
+        return None
+    if username.startswith("@"):
+        return username
+    return f"@{username}"
+
+
+def handle_activation_trigger(invitee_id: int, trigger: str) -> Optional[ActivationResult]:
+    if not settings.REF_ENABLED:
+        return None
+
+    referral = referrals_repo.get_referral_by_invitee(invitee_id)
+    if not referral or referral.status != "pending":
+        return None
+
+    if referral.expires_at and datetime.utcnow() > referral.expires_at:
+        referrals_repo.mark_referral_rejected(referral, "expired")
+        log_event(
+            "referral_rejected",
+            level="WARN",
+            reason="expired",
+            inviter_id=referral.inviter_id,
+            invitee_id=invitee_id,
+            trigger=trigger,
+        )
+        return ActivationResult(inviter_id=referral.inviter_id, reason="expired")
+
+    referrals_repo.mark_referral_activated(referral)
+    inviter = repo.get_user(referral.inviter_id)
+    username = _format_username(getattr(inviter, "username", None))
+
+    bonus = max(0, settings.REF_BONUS_INVITER)
+    granted = False
+    if bonus > 0 and not referrals_repo.is_banned(referral.inviter_id):
+        now = datetime.utcnow()
+        daily = referrals_repo.count_bonuses_since(referral.inviter_id, now - timedelta(days=1))
+        total = referrals_repo.count_total_bonuses(referral.inviter_id)
+        if daily >= settings.REF_MAX_BONUS_PER_DAY or total >= settings.REF_MAX_BONUS_TOTAL:
+            log_event(
+                "referral_rejected",
+                level="WARN",
+                reason="bonus_limit",
+                inviter_id=referral.inviter_id,
+                invitee_id=invitee_id,
+                daily=daily,
+                total=total,
+            )
+        else:
+            balance = referrals_repo.grant_credit(referral.inviter_id, bonus, "referral_inviter", referral)
+            referrals_repo.increment_bonuses(referral.inviter_id, bonus)
+            granted = True
+            update_context(credits_delta=bonus)
+            log_event(
+                "bonus_granted",
+                user_id=referral.inviter_id,
+                amount=bonus,
+                reason="referral_inviter",
+                balance=balance,
+                trigger=trigger,
+            )
+    log_event(
+        "referral_activated",
+        inviter_id=referral.inviter_id,
+        invitee_id=invitee_id,
+        trigger=trigger,
+        granted=granted,
+    )
+    return ActivationResult(
+        inviter_id=referral.inviter_id,
+        inviter_username=username,
+        granted=granted,
+        bonus=bonus if granted else 0,
+    )
+
+
+def build_referral_link(bot_username: str, user_id: int) -> str:
+    token = referrals_repo.get_token(user_id)
+    username = bot_username.lstrip("@")
+    return f"https://t.me/{username}?start=ref_{token}"
+
+
+def get_user_stats(user_id: int) -> dict:
+    stats = referrals_repo.get_stats(user_id)
+    if not stats:
+        return {
+            "invited": 0,
+            "activated": 0,
+            "bonuses": 0,
+        }
+    return {
+        "invited": stats.invited_count,
+        "activated": stats.activated_count,
+        "bonuses": stats.bonuses_earned,
+    }
+
+
+def list_recent_rewards(user_id: int, limit: int = 10):
+    return referrals_repo.get_recent_rewards(user_id, limit)
+
+
+def apply_promocode(invitee_id: int, code: str, *, is_new: bool) -> tuple[bool, str]:
+    if not settings.REF_ENABLED:
+        return False, "Реферальная программа временно недоступна."
+
+    promo_code = code.strip().upper()
+    promo = referrals_repo.ensure_promocode(promo_code)
+    if not promo or not promo.is_active:
+        return False, "Промокод не найден или не активен."
+
+    now = datetime.utcnow()
+    if promo.expires_at and promo.expires_at < now:
+        return False, "Срок действия промокода истёк."
+    if promo.max_uses is not None and promo.uses >= promo.max_uses:
+        return False, "Промокод уже исчерпан."
+
+    if not is_new:
+        return False, "Промокод доступен только новым пользователям."
+
+    user = repo.get_user(invitee_id)
+    if not user:
+        return False, "Пользователь не найден."
+    if (now - user.created_at).total_seconds() > settings.REF_PROMO_TTL_HOURS * 3600:
+        return False, "Увы, промокод можно применить только в течение первых часов после старта."
+
+    if not promo.inviter_id:
+        return False, "Промокод не привязан к приглашающему."
+    inviter_id = promo.inviter_id
+    if inviter_id == invitee_id:
+        return False, "Нельзя применить свой же промокод."
+
+    existing = referrals_repo.get_referral_by_invitee(invitee_id)
+    if existing:
+        return False, "Промокод уже был применён ранее."
+
+    expires_at = now + timedelta(hours=settings.REF_ATTRIBUTION_TTL_HOURS)
+    referral = referrals_repo.create_referral(
+        inviter_id,
+        invitee_id,
+        token=promo_code,
+        source="promo_code",
+        expires_at=expires_at,
+    )
+    referrals_repo.increment_promocode_usage(promo)
+    update_context(referral=_build_referral_dict(referral))
+    log_event(
+        "referral_attributed",
+        inviter_id=inviter_id,
+        invitee_id=invitee_id,
+        source="promo_code",
+    )
+
+    invitee_bonus = 0
+    if settings.REF_BONUS_INVITEE > 0:
+        invitee_bonus = settings.REF_BONUS_INVITEE
+        balance = referrals_repo.grant_credit(invitee_id, invitee_bonus, "referral_invitee", referral)
+        update_context(credits_delta=invitee_bonus)
+        log_event(
+            "bonus_granted",
+            user_id=invitee_id,
+            amount=invitee_bonus,
+            reason="referral_invitee",
+            balance=balance,
+        )
+
+    return True, "Промокод применён! Добро пожаловать в программу."
+
+
+def render_rules_text() -> str:
+    return (
+        "Зови друзей и получай бонусы 🎁\n"
+        "Дружбану — +1 кредит, тебе — +1 после первого отчёта/оплаты.\n"
+        f"Лимиты: до {settings.REF_MAX_BONUS_PER_DAY} бонусов/день, до {settings.REF_MAX_BONUS_TOTAL} всего."
+    )
+
+
+def admin_summary() -> dict:
+    data = referrals_repo.referral_summary()
+    top = list(referrals_repo.referral_top())
+    pending = list(referrals_repo.list_pending_referrals())
+    recent = list(referrals_repo.list_recent_referrals())
+    return {"summary": data, "top": top, "pending": pending, "recent": recent}
+
+
+def admin_get_referral(referral_id: int) -> Optional[Referral]:
+    return referrals_repo.get_referral(referral_id)
+
+
+def admin_referral_details(referral_id: int) -> Optional[dict]:
+    referral = referrals_repo.get_referral(referral_id)
+    if not referral:
+        return None
+    inviter = repo.get_user(referral.inviter_id)
+    invitee = repo.get_user(referral.invitee_id)
+    return {
+        "id": referral.id,
+        "inviter": inviter,
+        "invitee": invitee,
+        "status": referral.status,
+        "created_at": referral.created_at,
+        "activated_at": referral.activated_at,
+        "source": referral.source,
+        "token": referral.token,
+        "reason": referral.rejection_reason,
+    }
+
+
+def admin_activate_referral(referral_id: int, *, grant_bonus: bool = True) -> tuple[bool, str]:
+    referral = referrals_repo.get_referral(referral_id)
+    if not referral:
+        return False, "Реферал не найден."
+    if referral.status == "activated":
+        return False, "Реферал уже активирован."
+    referrals_repo.mark_referral_activated(referral)
+    if grant_bonus and settings.REF_BONUS_INVITER > 0:
+        referrals_repo.grant_credit(referral.inviter_id, settings.REF_BONUS_INVITER, "referral_inviter", referral)
+        referrals_repo.increment_bonuses(referral.inviter_id, settings.REF_BONUS_INVITER)
+    log_event("referral_activated", inviter_id=referral.inviter_id, invitee_id=referral.invitee_id, manual=True)
+    return True, "Реферал активирован."
+
+
+def admin_reject_referral(referral_id: int, reason: str) -> tuple[bool, str]:
+    referral = referrals_repo.get_referral(referral_id)
+    if not referral:
+        return False, "Реферал не найден."
+    if referral.status == "rejected":
+        return False, "Реферал уже отклонён."
+    referrals_repo.mark_referral_rejected(referral, reason)
+    log_event(
+        "referral_rejected",
+        inviter_id=referral.inviter_id,
+        invitee_id=referral.invitee_id,
+        reason=reason,
+        manual=True,
+    )
+    return True, "Реферал отклонён."

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -20,7 +20,17 @@ db = SqliteDatabase(
 
 def init_db() -> None:
     """Создать таблицы, если их ещё нет."""
-    from .models import User, Usage, Credit, Payment  # noqa
+    from .models import (
+        User,
+        Usage,
+        Credit,
+        Payment,
+        Referral,
+        ReferralStats,
+        PromoCode,
+        Ledger,
+        ReferralBan,
+    )  # noqa: WPS347
     db.connect(reuse_if_open=True)
-    db.create_tables([User, Usage, Credit, Payment])
+    db.create_tables([User, Usage, Credit, Payment, Referral, ReferralStats, PromoCode, Ledger, ReferralBan])
     db.close()

--- a/app/storage/referrals_repo.py
+++ b/app/storage/referrals_repo.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import datetime
+import secrets
+import string
+from typing import Iterable, Optional
+
+from peewee import fn
+
+from .db import db
+from .models import (
+    Credit,
+    Ledger,
+    PromoCode,
+    Referral,
+    ReferralBan,
+    ReferralStats,
+    User,
+)
+
+_TOKEN_ALPHABET = string.ascii_letters + string.digits
+
+
+def _generate_token(length: int = 10) -> str:
+    while True:
+        token = "".join(secrets.choice(_TOKEN_ALPHABET) for _ in range(length))
+        exists = ReferralStats.select().where(ReferralStats.token == token).exists()
+        if not exists:
+            return token
+
+
+def ensure_stats(user_id: int) -> ReferralStats:
+    from . import repo  # локальный импорт, чтобы избежать циклов
+
+    with db.atomic():
+        repo.ensure_user(user_id, None, None)
+        stats, created = ReferralStats.get_or_create(
+            user=user_id,
+            defaults={"token": _generate_token()},
+        )
+        if created:
+            return stats
+        if not stats.token:
+            token = _generate_token()
+            ReferralStats.update(token=token).where(ReferralStats.id == stats.id).execute()
+            stats.token = token
+        return stats
+
+
+def get_stats(user_id: int) -> Optional[ReferralStats]:
+    return ReferralStats.get_or_none(ReferralStats.user == user_id)
+
+
+def get_token(user_id: int) -> str:
+    stats = ensure_stats(user_id)
+    return stats.token
+
+
+def get_referral_by_invitee(invitee_id: int) -> Optional[Referral]:
+    return Referral.get_or_none(Referral.invitee == invitee_id)
+
+
+def find_referral_by_token(token: str) -> Optional[ReferralStats]:
+    return ReferralStats.get_or_none(ReferralStats.token == token)
+
+
+def create_referral(
+    inviter_id: int,
+    invitee_id: int,
+    *,
+    token: Optional[str],
+    source: str,
+    expires_at: Optional[datetime],
+) -> Referral:
+    from . import repo
+
+    now = datetime.utcnow()
+    with db.atomic():
+        repo.ensure_user(inviter_id, None, None)
+        repo.ensure_user(invitee_id, None, None)
+        ensure_stats(inviter_id)
+        referral = Referral.create(
+            inviter=inviter_id,
+            invitee=invitee_id,
+            token=token,
+            source=source,
+            expires_at=expires_at,
+            created_at=now,
+        )
+        ReferralStats.update(
+            invited_count=ReferralStats.invited_count + 1,
+            last_invited_at=now,
+        ).where(ReferralStats.user == inviter_id).execute()
+        return referral
+
+
+def mark_referral_rejected(referral: Referral, reason: str) -> None:
+    Referral.update(
+        status="rejected",
+        rejection_reason=reason,
+    ).where(Referral.id == referral.id).execute()
+
+
+def mark_referral_activated(referral: Referral) -> None:
+    now = datetime.utcnow()
+    Referral.update(
+        status="activated",
+        activated_at=now,
+    ).where(Referral.id == referral.id).execute()
+    ReferralStats.update(
+        activated_count=ReferralStats.activated_count + 1,
+    ).where(ReferralStats.user == referral.inviter_id).execute()
+
+
+def count_bonuses_since(user_id: int, since: datetime) -> int:
+    return (
+        Ledger.select(fn.COUNT(Ledger.id))
+        .where((Ledger.user == user_id) & (Ledger.ts >= since) & (Ledger.reason == "referral_inviter"))
+        .scalar()
+        or 0
+    )
+
+
+def count_total_bonuses(user_id: int) -> int:
+    return (
+        Ledger.select(fn.COUNT(Ledger.id))
+        .where((Ledger.user == user_id) & (Ledger.reason == "referral_inviter"))
+        .scalar()
+        or 0
+    )
+
+
+def increment_bonuses(inviter_id: int, delta: int) -> None:
+    now = datetime.utcnow()
+    ReferralStats.update(
+        bonuses_earned=ReferralStats.bonuses_earned + delta,
+        last_bonus_at=now,
+    ).where(ReferralStats.user == inviter_id).execute()
+
+
+def grant_credit(user_id: int, delta: int, reason: str, referral: Optional[Referral] = None) -> int:
+    from . import repo
+
+    with db.atomic():
+        repo.ensure_user(user_id, None, None)
+        credit, _ = Credit.get_or_create(user=user_id, defaults={"balance": 0})
+        new_balance = max(0, credit.balance + delta)
+        Credit.update(balance=new_balance).where(Credit.id == credit.id).execute()
+        Ledger.create(
+            user=user_id,
+            kind="credit",
+            delta=delta,
+            reason=reason,
+            related_referral=referral,
+            balance_after=new_balance,
+        )
+        return new_balance
+
+
+def get_recent_rewards(user_id: int, limit: int = 10) -> Iterable[Ledger]:
+    return (
+        Ledger.select()
+        .where(
+            (Ledger.user == user_id)
+            & (Ledger.reason.in_(["referral_inviter", "referral_invitee", "manual"]))
+        )
+        .order_by(Ledger.ts.desc())
+        .limit(limit)
+    )
+
+
+def ensure_promocode(code: str) -> Optional[PromoCode]:
+    return PromoCode.get_or_none(PromoCode.code == code)
+
+
+def increment_promocode_usage(promo: PromoCode) -> None:
+    PromoCode.update(uses=PromoCode.uses + 1).where(PromoCode.id == promo.id).execute()
+
+
+def is_banned(user_id: int) -> bool:
+    return ReferralBan.select().where(ReferralBan.user == user_id).exists()
+
+
+def referral_summary() -> dict[str, int]:
+    total_invited = Referral.select(fn.COUNT(Referral.id)).scalar() or 0
+    activated = Referral.select(fn.COUNT(Referral.id)).where(Referral.status == "activated").scalar() or 0
+    rejected = Referral.select(fn.COUNT(Referral.id)).where(Referral.status == "rejected").scalar() or 0
+    bonuses = (
+        Ledger.select(fn.SUM(Ledger.delta))
+        .where(Ledger.reason == "referral_inviter")
+        .scalar()
+        or 0
+    )
+    return {
+        "invited": total_invited,
+        "activated": activated,
+        "rejected": rejected,
+        "bonuses": bonuses,
+    }
+
+
+def referral_top(limit: int = 10) -> Iterable[ReferralStats]:
+    return (
+        ReferralStats.select()
+        .order_by(ReferralStats.activated_count.desc(), ReferralStats.invited_count.desc())
+        .limit(limit)
+    )
+
+
+def get_referral(referral_id: int) -> Optional[Referral]:
+    return Referral.get_or_none(Referral.id == referral_id)
+
+
+def list_recent_referrals(limit: int = 20) -> Iterable[Referral]:
+    return Referral.select().order_by(Referral.created_at.desc()).limit(limit)
+
+
+def list_pending_referrals(limit: int = 20) -> Iterable[Referral]:
+    return (
+        Referral.select()
+        .where(Referral.status == "pending")
+        .order_by(Referral.created_at.asc())
+        .limit(limit)
+    )

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -64,6 +64,7 @@ class OperationContext:
     quota: Dict[str, Any] | None = None
     credits_delta: int | None = None
     payment: Dict[str, Any] | None = None
+    referral: Dict[str, Any] | None = None
     ok: bool | None = None
     err: str | None = None
 
@@ -86,6 +87,7 @@ class OperationContext:
             "quota",
             "credits_delta",
             "payment",
+            "referral",
             "ok",
             "err",
         ):


### PR DESCRIPTION
## Summary
- add persistent referral models, repository helpers, and service layer covering deep links, promo codes, activation, and admin tools
- surface referral controls in start flow, new user commands, payments and parse success notifications, and extend logging/configuration to track referrals
- enrich admin panel and keyboards to expose referral metrics, manual moderation, and user-facing sharing experience

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd2ce71ca483209f7799470e4bfea4