### PR TITLE
Fix Ledger referral foreign key

### DIFF
--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -90,7 +90,7 @@ class Ledger(BaseModel):
     kind = CharField()  # credit|unlimited
     delta = IntegerField()
     reason = CharField()
-    related_referral = ForeignKeyField("Referral", null=True, on_delete="SET NULL")
+    related_referral = ForeignKeyField(Referral, null=True, on_delete="SET NULL")
     ts = DateTimeField(default=datetime.utcnow)
     balance_after = IntegerField(null=True)
 


### PR DESCRIPTION
## Summary
- update Ledger.related_referral to use the actual Referral model instead of a string reference

## Testing
- ./start.sh (fails: ModuleNotFoundError: No module named 'aiogram')

------
https://chatgpt.com/codex/tasks/task_e_68cd328d983c8320bf91c526e66ff67d