### PR TITLE
Implement interactive paywall purchase flow

### DIFF
--- a/app/handlers/payments.py
+++ b/app/handlers/payments.py
@@ -3,32 +3,39 @@ from __future__ import annotations
 from aiogram import Dispatcher, types
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
-from app.services import payments
-from app.services import referrals
+from app import keyboards
+from app.handlers import parse
+from app.services import paywall, payments, referrals
 from app.utils.logging import complete_operation, log_event, update_context
+from app.utils.admins import is_admin
 
 
-def _kb_packs() -> InlineKeyboardMarkup:
-    kb = InlineKeyboardMarkup(row_width=1)
-    kb.add(
-        InlineKeyboardButton("1 запрос — 49 ₽", callback_data="pay_create:p1"),
-        InlineKeyboardButton("3 запроса — 139 ₽", callback_data="pay_create:p3"),
-        InlineKeyboardButton("9 запросов — 399 ₽", callback_data="pay_create:p9"),
-        InlineKeyboardButton("Безлимит 30 дней — 1299 ₽", callback_data="pay_create:unlim30"),
-    )
-    return kb
+def _resolve_pack(data: str) -> str | None:
+    parts = data.split(":")
+    if len(parts) < 3:
+        return None
+    if parts[1] == "pack":
+        return {"1": "p1", "3": "p3", "9": "p9"}.get(parts[2])
+    if parts[1] == "unlim" and parts[2] == "30":
+        return "unlim30"
+    return None
 
 
 async def cmd_buy(message: types.Message):
     update_context(command="/buy")
     log_event("request_parsed", message="/buy", command="/buy")
-    await message.reply("Выберите пакет:", reply_markup=_kb_packs())
+    await message.reply(paywall.paywall_text(), reply_markup=paywall.paywall_keyboard())
 
 
-async def cb_create(call: types.CallbackQuery):
-    pack = call.data.split(":", 1)[1]
-    update_context(command="pay_create", args={"pack": pack})
-    log_event("request_parsed", message=f"pay_create {pack}", command="pay_create", args={"pack": pack})
+async def _start_payment_flow(call: types.CallbackQuery, pack: str) -> None:
+    update_context(command="buy_pack", args={"pack": pack})
+    log_event("buy_cta_clicked", message=f"buy_cta {pack}", args={"pack": pack})
+
+    pending = paywall.get_pending_payment(call.from_user.id)
+    if pending and pending.pack == pack:
+        await call.answer("Оплата уже открыта — проверь ссылку выше.")
+        return
+
     me = await call.bot.get_me()
     try:
         pid, url = payments.create_payment(call.from_user.id, pack, bot_username=me.username)
@@ -37,15 +44,54 @@ async def cb_create(call: types.CallbackQuery):
         await call.answer("Ошибка создания платежа", show_alert=True)
         complete_operation(ok=False, err="payment_create_failed")
         return
-    kb = InlineKeyboardMarkup().add(
-        InlineKeyboardButton("💳 Оплатить", url=url),
-        InlineKeyboardButton("✅ Проверить оплату", callback_data=f"pay_check:{pid}"),
-    )
-    await call.message.reply(
-        f"Заказ оформлен: {payments.TITLES[pack]}.\nПосле оплаты жми «Проверить оплату».",
+
+    paywall.set_pending_payment(call.from_user.id, pid, pack, url)
+
+    price_text = paywall.pack_price_text(pack)
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(InlineKeyboardButton("💳 Оплатить", url=url))
+    kb.add(InlineKeyboardButton("✅ Проверить оплату", callback_data=f"pay_check:{pid}"))
+
+    title = payments.TITLES.get(pack, pack)
+    price_part = f" — {price_text}" if price_text else ""
+    await call.message.answer(
+        f"Заказ оформлен: {title}{price_part}.\nПосле оплаты жми «Проверить оплату».",
         reply_markup=kb,
     )
+    await call.message.answer("Открыл оплату. После успешного платежа доступ появится автоматически.")
     await call.answer()
+
+
+async def cb_create(call: types.CallbackQuery):
+    pack = call.data.split(":", 1)[1]
+    update_context(command="pay_create", args={"pack": pack})
+    log_event("request_parsed", message=f"pay_create {pack}", command="pay_create", args={"pack": pack})
+    await _start_payment_flow(call, pack)
+
+
+async def cb_buy_pack(call: types.CallbackQuery):
+    pack = _resolve_pack(call.data)
+    if not pack:
+        await call.answer()
+        return
+    await _start_payment_flow(call, pack)
+
+
+async def cb_buy_open(call: types.CallbackQuery):
+    await call.answer()
+    await call.message.answer(paywall.paywall_text(), reply_markup=paywall.paywall_keyboard())
+
+
+async def cb_buy_info(call: types.CallbackQuery):
+    await call.answer()
+    await call.message.answer(paywall.paywall_text(), reply_markup=paywall.paywall_keyboard())
+
+
+async def cb_buy_back(call: types.CallbackQuery):
+    await call.answer()
+    await call.message.answer(
+        "Главное меню:", reply_markup=keyboards.main_kb(is_admin=is_admin(call.from_user.id))
+    )
 
 
 async def cb_check(call: types.CallbackQuery):
@@ -53,14 +99,18 @@ async def cb_check(call: types.CallbackQuery):
     update_context(command="pay_check", args={"payment_id": pid})
     log_event("request_parsed", message=f"pay_check {pid}", command="pay_check", args={"payment_id": pid})
     try:
-        msg, activation = payments.check_and_apply(call.from_user.id, pid)
+        msg, activation, status = payments.check_and_apply(call.from_user.id, pid)
     except Exception as exc:
         log_event("payment_failed", level="ERROR", err=str(exc), message="payment check failed")
-        msg, activation = "Не удалось проверить оплату. Попробуйте позже.", None
+        msg, activation, status = "Не удалось проверить оплату. Попробуйте позже.", None, "error"
         complete_operation(ok=False, err="payment_check_failed")
     await call.message.reply(msg)
     if activation:
         await _notify_referral_activation(call.bot, activation, call.from_user)
+    if status != "pending":
+        paywall.clear_pending_payment(call.from_user.id)
+    if status == "succeeded":
+        await parse.prompt_resume(call.bot, call.from_user.id)
     await call.answer()
 
 
@@ -72,14 +122,18 @@ async def start_with_payload(message: types.Message):
     update_context(command="start_payload", args={"payment_id": pid})
     log_event("request_parsed", message=f"/start payload {pid}", command="/start", args={"payment_id": pid})
     try:
-        msg, activation = payments.check_and_apply(message.from_user.id, pid)
+        msg, activation, status = payments.check_and_apply(message.from_user.id, pid)
     except Exception as exc:
         log_event("payment_failed", level="ERROR", err=str(exc), message="payment check failed")
-        msg, activation = "Не удалось проверить оплату. Попробуйте позже.", None
+        msg, activation, status = "Не удалось проверить оплату. Попробуйте позже.", None, "error"
         complete_operation(ok=False, err="payment_check_failed")
     await message.reply(msg)
     if activation:
         await _notify_referral_activation(message.bot, activation, message.from_user)
+    if status != "pending":
+        paywall.clear_pending_payment(message.from_user.id)
+    if status == "succeeded":
+        await parse.prompt_resume(message.bot, message.from_user.id)
 
 
 async def _notify_referral_activation(bot, activation: referrals.ActivationResult, invitee: types.User | None) -> None:
@@ -115,6 +169,14 @@ def _format_user_mention(user: types.User | None) -> str:
 def register(dp: Dispatcher):
     dp.register_message_handler(cmd_buy, commands=["buy"])
     dp.register_message_handler(cmd_buy, lambda m: m.text in {"💳 Купить", "Купить"}, state="*")
+    dp.register_callback_query_handler(cb_buy_open, lambda c: c.data == "buy:open", state="*")
+    dp.register_callback_query_handler(cb_buy_info, lambda c: c.data == "buy:info", state="*")
+    dp.register_callback_query_handler(cb_buy_back, lambda c: c.data == "buy:back", state="*")
+    dp.register_callback_query_handler(
+        cb_buy_pack,
+        lambda c: c.data and (c.data.startswith("buy:pack:") or c.data.startswith("buy:unlim:")),
+        state="*",
+    )
     dp.register_callback_query_handler(cb_create, lambda c: c.data and c.data.startswith("pay_create:"))
     dp.register_callback_query_handler(cb_check, lambda c: c.data and c.data.startswith("pay_check:"))
     dp.register_message_handler(start_with_payload, commands=["start"])

--- a/app/handlers/status.py
+++ b/app/handlers/status.py
@@ -2,6 +2,7 @@ import os
 
 import aiogram
 from aiogram import Dispatcher, types
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from app.storage.repo import free_used_this_month, get_credits, is_unlimited_active
 from app.utils.logging import log_event, update_context
@@ -34,7 +35,8 @@ async def cmd_status(message: types.Message):
         "",
         f"aiogram: {aiogram.__version__}",
     ]
-    await message.reply("\n".join(lines))
+    kb = InlineKeyboardMarkup().add(InlineKeyboardButton("💳 Купить", callback_data="buy:open"))
+    await message.reply("\n".join(lines), reply_markup=kb)
 
 def register(dp: Dispatcher):
     dp.register_message_handler(cmd_status, commands=["status"])

--- a/app/services/paywall.py
+++ b/app/services/paywall.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from . import payments
+
+REQUEST_TTL_SECONDS = int(os.getenv("PAYWALL_REQUEST_TTL", "900"))
+PAYMENT_TTL_SECONDS = int(os.getenv("PAYWALL_PAYMENT_TTL", "900"))
+
+
+def _now() -> datetime:
+    return datetime.utcnow()
+
+
+def _format_rub(amount_cop: int) -> str:
+    rub = int(round(amount_cop / 100))
+    return f"{rub:,}".replace(",", " ")
+
+
+@dataclass
+class SavedRequest:
+    kind: str
+    query: str
+    city: str
+    overrides: Dict[str, Any] = field(default_factory=dict)
+    area_id: Optional[int] = None
+    total: Optional[int] = None
+    approx_total: Optional[int] = None
+    created_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        self.overrides = dict(self.overrides or {})
+
+    def summary(self) -> str:
+        title = (self.query or "").strip() or "—"
+        city = (self.city or "").strip() or "—"
+        return f"{title}; {city}"
+
+    def to_log(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "kind": self.kind,
+            "query": self.query,
+            "city": self.city,
+        }
+        if self.total is not None:
+            payload["total"] = self.total
+        if self.area_id is not None:
+            payload["area_id"] = self.area_id
+        if self.overrides:
+            payload["overrides"] = self.overrides
+        return payload
+
+
+@dataclass
+class PendingPayment:
+    payment_id: str
+    pack: str
+    url: str
+    created_at: datetime = field(default_factory=_now)
+
+    def is_expired(self) -> bool:
+        return (_now() - self.created_at) > timedelta(seconds=PAYMENT_TTL_SECONDS)
+
+
+_REQUEST_CACHE: Dict[int, tuple[datetime, SavedRequest]] = {}
+_PENDING_PAYMENTS: Dict[int, PendingPayment] = {}
+
+
+def save_request(user_id: int, request: SavedRequest) -> None:
+    expires_at = _now() + timedelta(seconds=REQUEST_TTL_SECONDS)
+    _REQUEST_CACHE[user_id] = (expires_at, request)
+
+
+def get_request(user_id: int) -> Optional[SavedRequest]:
+    entry = _REQUEST_CACHE.get(user_id)
+    if not entry:
+        return None
+    expires_at, request = entry
+    if _now() > expires_at:
+        _REQUEST_CACHE.pop(user_id, None)
+        return None
+    return request
+
+
+def consume_request(user_id: int) -> Optional[SavedRequest]:
+    request = get_request(user_id)
+    if request is None:
+        return None
+    _REQUEST_CACHE.pop(user_id, None)
+    return request
+
+
+def clear_request(user_id: int) -> None:
+    _REQUEST_CACHE.pop(user_id, None)
+
+
+def set_pending_payment(user_id: int, payment_id: str, pack: str, url: str) -> PendingPayment:
+    pending = PendingPayment(payment_id=payment_id, pack=pack, url=url)
+    _PENDING_PAYMENTS[user_id] = pending
+    return pending
+
+
+def get_pending_payment(user_id: int) -> Optional[PendingPayment]:
+    pending = _PENDING_PAYMENTS.get(user_id)
+    if not pending:
+        return None
+    if pending.is_expired():
+        _PENDING_PAYMENTS.pop(user_id, None)
+        return None
+    return pending
+
+
+def clear_pending_payment(user_id: int) -> None:
+    _PENDING_PAYMENTS.pop(user_id, None)
+
+
+def paywall_text() -> str:
+    lines = [
+        "Лимит исчерпан: бесплатные запросы на этот месяц закончились, платные кредиты отсутствуют.",
+        "",
+        "Можно оформить доступ:",
+    ]
+    for pack_id in payments.PACK_ORDER:
+        price_cop = payments.PRICES.get(pack_id)
+        if price_cop is None:
+            continue
+        title = payments.TITLES.get(pack_id, pack_id)
+        lines.append(f"• {title} — ₽{_format_rub(price_cop)}")
+    return "\n".join(lines)
+
+
+def pack_price_text(pack_id: str) -> str:
+    price_cop = payments.PRICES.get(pack_id)
+    if price_cop is None:
+        return ""
+    return f"₽{_format_rub(price_cop)}"
+
+
+def paywall_keyboard() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(
+        InlineKeyboardButton("Купить 1", callback_data="buy:pack:1"),
+        InlineKeyboardButton("Купить 3", callback_data="buy:pack:3"),
+        InlineKeyboardButton("Купить 9", callback_data="buy:pack:9"),
+        InlineKeyboardButton("Безлимит на 30 дней", callback_data="buy:unlim:30"),
+    )
+    kb.row(InlineKeyboardButton("Тарифы", callback_data="buy:info"))
+    kb.row(InlineKeyboardButton("Назад в меню", callback_data="buy:back"))
+    return kb
+
+
+def resume_keyboard() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=2)
+    kb.add(
+        InlineKeyboardButton("Да, запусти", callback_data="resume:last"),
+        InlineKeyboardButton("Нет, позже", callback_data="resume:skip"),
+    )
+    return kb

--- a/app/services/quota.py
+++ b/app/services/quota.py
@@ -1,54 +1,96 @@
 from __future__ import annotations
+
 import os
 from dataclasses import dataclass
-from typing import Optional, Literal
 from datetime import datetime
+from typing import Optional, Literal
+
 from app.storage.repo import (
-    ensure_user, is_unlimited_active, free_used_this_month,
-    record_usage, get_credits, consume_credit,
+    consume_credit,
+    ensure_user,
+    free_used_this_month,
+    get_credits,
+    is_unlimited_active,
+    record_usage,
 )
 
 FREE_PER_MONTH = int(os.getenv("FREE_PER_MONTH", "3"))
 
 Mode = Literal["unlimited", "free", "paid", "none"]
 
+
 @dataclass
 class QuotaDecision:
     allowed: bool
     mode: Mode
+    free_used: int
     free_left: int
     credits: int
     unlimited_until: Optional[datetime]
-    message: str = ""
 
-def check_and_consume(user_id: int, username: Optional[str], full_name: Optional[str]) -> QuotaDecision:
-    # sync user meta + last_seen
+
+@dataclass
+class QuotaUsageOutcome:
+    mode: Mode
+    free_used: int
+    free_left: int
+    credits: int
+    unlimited_until: Optional[datetime]
+    credits_delta: int = 0
+
+
+def check_quota(user_id: int, username: Optional[str], full_name: Optional[str]) -> QuotaDecision:
     ensure_user(user_id, username, full_name)
 
-    # 1) Unlimited plan?
+    used = free_used_this_month(user_id)
+    free_left = max(0, FREE_PER_MONTH - used)
+    credits = get_credits(user_id)
+
     active, until = is_unlimited_active(user_id)
     if active:
-        return QuotaDecision(True, "unlimited", free_left=0, credits=get_credits(user_id), unlimited_until=until)
+        return QuotaDecision(True, "unlimited", free_used=used, free_left=free_left, credits=credits, unlimited_until=until)
 
-    # 2) Free monthly
-    used = free_used_this_month(user_id)
+    if credits > 0:
+        return QuotaDecision(True, "paid", free_used=used, free_left=free_left, credits=credits, unlimited_until=None)
+
     if used < FREE_PER_MONTH:
+        return QuotaDecision(
+            True,
+            "free",
+            free_used=used,
+            free_left=free_left,
+            credits=credits,
+            unlimited_until=None,
+        )
+
+    return QuotaDecision(False, "none", free_used=used, free_left=0, credits=credits, unlimited_until=None)
+
+
+def commit_usage(user_id: int, decision: QuotaDecision) -> Optional[QuotaUsageOutcome]:
+    if not decision.allowed:
+        return None
+
+    if decision.mode == "unlimited":
+        credits = get_credits(user_id)
+        used = free_used_this_month(user_id)
+        free_left = max(0, FREE_PER_MONTH - used)
+        active, until = is_unlimited_active(user_id)
+        return QuotaUsageOutcome("unlimited", used, free_left, credits, until if active else None, credits_delta=0)
+
+    if decision.mode == "free":
         record_usage(user_id, "free")
-        left = max(0, FREE_PER_MONTH - (used + 1))
-        return QuotaDecision(True, "free", free_left=left, credits=get_credits(user_id), unlimited_until=None)
+        used = free_used_this_month(user_id)
+        free_left = max(0, FREE_PER_MONTH - used)
+        credits = get_credits(user_id)
+        return QuotaUsageOutcome("free", used, free_left, credits, None, credits_delta=0)
 
-    # 3) Paid credits
-    if consume_credit(user_id):
-        return QuotaDecision(True, "paid", free_left=0, credits=get_credits(user_id), unlimited_until=None)
+    if decision.mode == "paid":
+        credits_delta = -1 if consume_credit(user_id) else 0
+        if credits_delta:
+            record_usage(user_id, "paid")
+        used = free_used_this_month(user_id)
+        free_left = max(0, FREE_PER_MONTH - used)
+        credits = get_credits(user_id)
+        return QuotaUsageOutcome("paid", used, free_left, credits, None, credits_delta=credits_delta)
 
-    # 4) No quota
-    return QuotaDecision(
-        False, "none",
-        free_left=0,
-        credits=get_credits(user_id),
-        unlimited_until=None,
-        message=(
-            "Лимит исчерпан: 3 бесплатных запроса в месяц использованы и платных кредитов нет.\n"
-            "Скоро добавим оплату — пока попробуй позже 🙏"
-        ),
-    )
+    return None


### PR DESCRIPTION
## Summary
- add a reusable paywall service to format pricing, cache blocked requests, and track pending payments
- rework parsing handlers to gate heavy operations on new quota checks, surface purchase CTAs, and offer automatic resume after successful payment
- update payment and status handlers plus payment/quota services for configurable pricing, payment status reporting, and new buy callbacks

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd5752a9448320b5b23e3d4af46d73