### PR TITLE
Restore classic paywall buttons

### DIFF
--- a/app/services/paywall.py
+++ b/app/services/paywall.py
@@ -120,18 +120,10 @@ def clear_pending_payment(user_id: int) -> None:
 
 
 def paywall_text() -> str:
-    lines = [
-        "Лимит исчерпан: бесплатные запросы на этот месяц закончились, платные кредиты отсутствуют.",
-        "",
-        "Можно оформить доступ:",
-    ]
-    for pack_id in payments.PACK_ORDER:
-        price_cop = payments.PRICES.get(pack_id)
-        if price_cop is None:
-            continue
-        title = payments.TITLES.get(pack_id, pack_id)
-        lines.append(f"• {title} — ₽{_format_rub(price_cop)}")
-    return "\n".join(lines)
+    return (
+        "Лимит исчерпан: бесплатные запросы на этот месяц закончились, "
+        "платные кредиты отсутствуют."
+    )
 
 
 def pack_price_text(pack_id: str) -> str:
@@ -141,14 +133,27 @@ def pack_price_text(pack_id: str) -> str:
     return f"₽{_format_rub(price_cop)}"
 
 
+def _pack_callback_data(pack_id: str) -> str | None:
+    if pack_id == "unlim30":
+        return "buy:unlim:30"
+    mapping = {
+        "p1": "buy:pack:1",
+        "p3": "buy:pack:3",
+        "p9": "buy:pack:9",
+    }
+    return mapping.get(pack_id)
+
+
 def paywall_keyboard() -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup(row_width=1)
-    kb.add(
-        InlineKeyboardButton("Купить 1", callback_data="buy:pack:1"),
-        InlineKeyboardButton("Купить 3", callback_data="buy:pack:3"),
-        InlineKeyboardButton("Купить 9", callback_data="buy:pack:9"),
-        InlineKeyboardButton("Безлимит на 30 дней", callback_data="buy:unlim:30"),
-    )
+    for pack_id in payments.PACK_ORDER:
+        callback_data = _pack_callback_data(pack_id)
+        if not callback_data:
+            continue
+        title = payments.TITLES.get(pack_id, pack_id)
+        price_text = pack_price_text(pack_id)
+        button_text = f"{title} — {price_text}" if price_text else title
+        kb.add(InlineKeyboardButton(button_text, callback_data=callback_data))
     kb.row(InlineKeyboardButton("Тарифы", callback_data="buy:info"))
     kb.row(InlineKeyboardButton("Назад в меню", callback_data="buy:back"))
     return kb


### PR DESCRIPTION
## Summary
- restore the paywall inline keyboard labels to the classic pack descriptions while keeping existing callbacks
- centralize callback resolution for packs so button text follows configured titles and prices
- remove the price list text from the paywall message while retaining the buttons

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5d1a9ab48320922c476e17bec7c2