### PR TITLE
Add report share flow with referral deep link

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -23,7 +23,8 @@ from ..services import parser_adapter
 from ..services import referrals
 from ..services import validator  # валидация запроса
 from ..services import chips
-from ..services.mini_analytics import register_context, render_mini_analytics
+from ..services.mini_analytics import get_summary, register_context, render_mini_analytics
+from ..services import report_share
 from ..services import paywall
 from ..services.quota import FREE_PER_MONTH, QuotaDecision, check_quota, commit_usage
 from app import keyboards
@@ -306,6 +307,14 @@ def _main_menu_kb(message: types.Message, *, user: types.User | None = None):
     return keyboards.main_kb(is_admin=is_admin(user_id))
 
 
+def _report_actions_keyboard() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(InlineKeyboardButton("📬 Поделиться отчётом", callback_data="report_share"))
+    kb.add(InlineKeyboardButton("🔁 Ещё раз", callback_data="report_again"))
+    kb.add(InlineKeyboardButton("🏠 Меню", callback_data="report_menu"))
+    return kb
+
+
 def _keywords_keyboard() -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup()
     kb.row(
@@ -414,17 +423,38 @@ async def _send_report_with_analytics(
     reply_markup=None,
 ) -> None:
     register_context(path, title=title, city=city)
-    await message.answer_document(InputFile(path), reply_markup=reply_markup)
-    if getattr(message, "from_user", None):
-        chips.record_success(message.from_user.id, title, city)
+    share_kb = _report_actions_keyboard()
+    await message.answer_document(InputFile(path), reply_markup=share_kb)
+    person = getattr(message, "from_user", None)
+    if person:
+        chips.record_success(person.id, title, city)
+    include_list = _ensure_str_list(include)
+    exclude_list = _ensure_str_list(exclude)
     text = render_mini_analytics(
         path,
         approx_total=approx_total,
-        include=_ensure_str_list(include),
-        exclude=_ensure_str_list(exclude),
+        include=include_list,
+        exclude=exclude_list,
     )
+    summary = get_summary(path)
+    if person:
+        report_share.save_last_report(
+            person.id,
+            role=title,
+            city=city,
+            include=include_list,
+            exclude=exclude_list,
+            volume=approx_total,
+            path=path,
+            median=getattr(summary, "median", None),
+            low=getattr(summary, "low", None),
+            high=getattr(summary, "high", None),
+            top_companies=getattr(summary, "top_companies", None),
+        )
     if text:
-        await message.answer(text, disable_web_page_preview=True)
+        await message.answer(text, disable_web_page_preview=True, reply_markup=reply_markup)
+    elif reply_markup is not None:
+        await message.answer("Готово ✅", reply_markup=reply_markup)
     activation = referrals.handle_activation_trigger(message.from_user.id, "report")
     if activation and activation.inviter_id:
         mention = _format_user_mention(message.from_user)
@@ -441,6 +471,48 @@ async def _send_report_with_analytics(
                 inviter_id=activation.inviter_id,
                 err=str(exc),
             )
+
+
+async def cb_report_share(call: types.CallbackQuery):
+    await call.answer()
+    snapshot = report_share.get_last_report(call.from_user.id)
+    if not snapshot:
+        await call.message.answer("Сначала запусти поиск.")
+        return
+    log_event(
+        "share_opened",
+        user_id=call.from_user.id,
+        role=snapshot.role,
+        city=snapshot.city,
+    )
+    me = await call.bot.get_me()
+    link = report_share.build_share_link(me.username or "", call.from_user.id)
+    share_text = report_share.build_share_text(snapshot, link)
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(InlineKeyboardButton("Скопировать текст", callback_data="report_share_copy"))
+    await call.message.answer(share_text, reply_markup=kb, disable_web_page_preview=True)
+
+
+async def cb_report_share_copy(call: types.CallbackQuery):
+    snapshot = report_share.get_last_report(call.from_user.id)
+    if not snapshot:
+        await call.answer("Сначала запусти поиск.", show_alert=True)
+        return
+    me = await call.bot.get_me()
+    link = report_share.build_share_link(me.username or "", call.from_user.id)
+    share_text = report_share.build_share_text(snapshot, link)
+    await call.answer(share_text, show_alert=True)
+
+
+async def cb_report_again(call: types.CallbackQuery, state: FSMContext):
+    await call.answer()
+    await cmd_parse(call.message, state)
+
+
+async def cb_report_menu(call: types.CallbackQuery):
+    await call.answer()
+    kb = keyboards.main_kb(is_admin=is_admin(call.from_user.id))
+    await call.message.answer("Главное меню:", reply_markup=kb)
 
 
 async def _run_parser_bypass_validation(
@@ -1328,5 +1400,9 @@ def register(dp: Dispatcher):
     # выбор объёма и превью
     dp.register_callback_query_handler(cb_qty,     lambda c: c.data and c.data.startswith("qty:"),     state="*")
     dp.register_callback_query_handler(cb_preview, lambda c: c.data and c.data.startswith("preview:"), state="*")
+    dp.register_callback_query_handler(cb_report_share, lambda c: c.data == "report_share", state="*")
+    dp.register_callback_query_handler(cb_report_share_copy, lambda c: c.data == "report_share_copy", state="*")
+    dp.register_callback_query_handler(cb_report_again, lambda c: c.data == "report_again", state="*")
+    dp.register_callback_query_handler(cb_report_menu, lambda c: c.data == "report_menu", state="*")
     dp.register_callback_query_handler(cb_resume_yes,  lambda c: c.data == "resume:last", state="*")
     dp.register_callback_query_handler(cb_resume_skip, lambda c: c.data == "resume:skip", state="*")

--- a/app/services/mini_analytics.py
+++ b/app/services/mini_analytics.py
@@ -5,6 +5,7 @@ import logging
 import math
 import re
 from collections import Counter
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable, Sequence
@@ -19,10 +20,19 @@ except Exception:  # pragma: no cover - gracefully handle missing pandas
 log = logging.getLogger(__name__)
 
 _CONTEXT: dict[str, tuple[str, str]] = {}
+_SUMMARY: dict[str, "MiniSummary"] = {}
 
 _THIN_NBSP = "\u202f"
 
-__all__ = ["register_context", "render_mini_analytics"]
+__all__ = ["register_context", "render_mini_analytics", "get_summary"]
+
+
+@dataclass
+class MiniSummary:
+    median: str | None = None
+    low: str | None = None
+    high: str | None = None
+    top_companies: list[str] = field(default_factory=list)
 
 _SPARKLINE_LEVELS = "▁▂▃▄▅▆▇█"
 _SCHEDULE_MAP = (
@@ -134,6 +144,12 @@ def register_context(path: Path, *, title: str | None, city: str | None) -> None
     safe_title = (title or "").strip()
     safe_city = (city or "").strip()
     _CONTEXT[key] = (safe_title, safe_city)
+    _SUMMARY.pop(key, None)
+
+
+def get_summary(path: Path) -> MiniSummary | None:
+    key = str(Path(path).resolve())
+    return _SUMMARY.get(key)
 
 
 def _format_int(value: int | float | None) -> str:
@@ -414,6 +430,7 @@ def render_mini_analytics(
         header_lines.append(processed_line)
 
         sections: list[str] = ["\n".join(header_lines)]
+        summary = MiniSummary()
 
         # Salary block
         salary_lines: list[str] = []
@@ -463,12 +480,19 @@ def render_mini_analytics(
                     if processed:
                         share_val = (available_mask.sum() / processed) * 100
 
+                    median_text = _format_money(median_val)
+                    low_text = _format_money(p10_val)
+                    high_text = _format_money(p90_val)
+                    summary.median = median_text
+                    summary.low = low_text
+                    summary.high = high_text
+
                     salary_lines.extend(
                         [
                             "<b>💰 Вилки (₽/мес, midpoint)</b>",
-                            f"• медиана: {_format_money(median_val)}",
-                            f"• низ рынка: {_format_money(p10_val)}",
-                            f"• верх рынка: {_format_money(p90_val)}",
+                            f"• медиана: {median_text}",
+                            f"• низ рынка: {low_text}",
+                            f"• верх рынка: {high_text}",
                         ]
                     )
                     if share_val is not None:
@@ -484,12 +508,17 @@ def render_mini_analytics(
             combined = combined[combined["norm"].str.len() > 0]
             if not combined.empty:
                 counts = combined.groupby("norm").size().sort_values(ascending=False)
-                top_rows = []
+                top_rows: list[str] = []
+                collected_companies: list[str] = []
                 for idx, (norm_name, count) in enumerate(counts.head(5).items(), start=1):
                     display_name = combined[combined["norm"] == norm_name]["orig"].iloc[0]
+                    if len(collected_companies) < 3:
+                        collected_companies.append(str(display_name))
                     top_rows.append(f"{idx}) {html.escape(display_name)} — {_format_int(count)}")
                 if top_rows:
                     sections.append("\n".join(["<b>🏢 Топ работодателей</b>"] + top_rows))
+                if collected_companies:
+                    summary.top_companies = collected_companies
 
         # Schedule / format
         if "schedule" in df.columns:
@@ -565,7 +594,9 @@ def render_mini_analytics(
         if filters_line:
             sections.append(filters_line)
 
-        return "\n\n".join(sections)
+        text = "\n\n".join(sections)
+        _SUMMARY[key] = summary
+        return text
     except Exception as exc:  # pragma: no cover
         log.warning("mini_analytics: failed to render analytics for %s: %s", path, exc, exc_info=True)
         return None

--- a/app/services/report_share.py
+++ b/app/services/report_share.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from app.config import settings
+from app.services import referrals
+
+
+@dataclass
+class ReportSnapshot:
+    role: str
+    city: str
+    include: tuple[str, ...]
+    exclude: tuple[str, ...]
+    volume: int | None
+    path: Path
+    generated_at: datetime
+    median: str | None
+    low: str | None
+    high: str | None
+    top_companies: tuple[str, ...]
+
+
+_LAST_REPORTS: dict[int, ReportSnapshot] = {}
+
+
+def _normalize_list(values: Iterable[str] | None) -> tuple[str, ...]:
+    if not values:
+        return tuple()
+    cleaned = []
+    for value in values:
+        text = str(value).strip()
+        if text:
+            cleaned.append(text)
+    return tuple(cleaned)
+
+
+def save_last_report(
+    user_id: int,
+    *,
+    role: str,
+    city: str,
+    include: Sequence[str] | None,
+    exclude: Sequence[str] | None,
+    volume: int | None,
+    path: Path,
+    median: str | None,
+    low: str | None,
+    high: str | None,
+    top_companies: Sequence[str] | None,
+) -> None:
+    snapshot = ReportSnapshot(
+        role=(role or "").strip(),
+        city=(city or "").strip(),
+        include=_normalize_list(include),
+        exclude=_normalize_list(exclude),
+        volume=volume,
+        path=Path(path).resolve(),
+        generated_at=datetime.utcnow(),
+        median=(median or None),
+        low=(low or None),
+        high=(high or None),
+        top_companies=_normalize_list(top_companies),
+    )
+    _LAST_REPORTS[user_id] = snapshot
+
+
+def get_last_report(user_id: int) -> ReportSnapshot | None:
+    return _LAST_REPORTS.get(user_id)
+
+
+def build_share_link(bot_username: str, user_id: int) -> str:
+    username = bot_username.lstrip("@")
+    if settings.REF_ENABLED:
+        base_link = referrals.build_referral_link(bot_username, user_id)
+        parsed = urlsplit(base_link)
+        query = parse_qsl(parsed.query, keep_blank_values=True)
+        token = None
+        for name, value in query:
+            if name == "start":
+                token = value
+                break
+        if token is None:
+            token = f"ref_{user_id}"
+            query.append(("start", token))
+        query.append(("utm_source", "share"))
+        ref_code = token.replace("ref_", "", 1) if token else ""
+        if ref_code:
+            query.append(("ref_code", ref_code))
+        new_query = urlencode(query, doseq=True)
+        return urlunsplit(parsed._replace(query=new_query))
+    return f"https://t.me/{username}?start=ref_{user_id}"
+
+
+def _format_value(value: str | None) -> str:
+    value = (value or "").strip()
+    return value or "нет данных"
+
+
+def build_share_text(report: ReportSnapshot, link: str) -> str:
+    role = report.role or "—"
+    city = report.city or "—"
+    median = _format_value(report.median)
+    low = _format_value(report.low)
+    high = _format_value(report.high)
+    top = ", ".join(report.top_companies[:3]) if report.top_companies else "—"
+    if not top or top == "—":
+        top = "нет данных"
+    lines = [
+        f"Отчёт по {role} • {city}",
+        f"Медиана {median} (низ {low}, верх {high})",
+        f"Топ работодателей: {top}. Скачать: {link}",
+    ]
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- capture mini-analytics salary stats and top employers for later reuse
- persist per-user report metadata and expose helper utilities for sharing
- add share/repeat/menu inline actions after report delivery with handlers to build referral links and copy-ready text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d29b52b3f48320aa2a8a813090e320