### PR TITLE
Adjust report share copy flow

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -501,7 +501,8 @@ async def cb_report_share_copy(call: types.CallbackQuery):
     me = await call.bot.get_me()
     link = report_share.build_share_link(me.username or "", call.from_user.id)
     share_text = report_share.build_share_text(snapshot, link)
-    await call.answer(share_text, show_alert=True)
+    await call.answer("Скопируй текст ниже 👇", show_alert=True)
+    await call.message.answer(share_text, disable_web_page_preview=True)
 
 
 async def cb_report_again(call: types.CallbackQuery, state: FSMContext):


### PR DESCRIPTION
## Summary
- replace the long callback alert with a short copy instruction when sharing a report
- send the full share text as a regular message so it remains available for copying

## Testing
- not run (manual Telegram verification required)


------
https://chatgpt.com/codex/tasks/task_e_68d2b36a38bc832097dfa6d0ac41ec7c