### PR TITLE
Use Replit PORT env for web server

### DIFF
--- a/.replit
+++ b/.replit
@@ -5,10 +5,6 @@ modules = ["python-3.11"]
 localPort = 5000
 externalPort = 80
 
-[[ports]]
-localPort = 8080
-externalPort = 8080
-
 [nix]
 packages = ["glibcLocales", "xcodebuild", "zlib", "mailutils", "imagemagick6"]
 

--- a/app/config.py
+++ b/app/config.py
@@ -33,11 +33,16 @@ def _load() -> Settings:
             return default
         return value.strip().lower() in {"1", "true", "yes", "on"}
 
+    webapp_port_value = os.getenv("WEBAPP_PORT")
+    if not webapp_port_value:
+        webapp_port_value = os.getenv("PORT")
+    webapp_port = int(webapp_port_value or "8080")
+
     cfg = Settings(
         TELEGRAM_BOT_TOKEN=os.getenv("TELEGRAM_BOT_TOKEN", ""),
         MODE=os.getenv("MODE", "polling"),
         WEBAPP_HOST=os.getenv("WEBAPP_HOST", "0.0.0.0"),
-        WEBAPP_PORT=int(os.getenv("WEBAPP_PORT", "8080")),
+        WEBAPP_PORT=webapp_port,
         WEBHOOK_URL=os.getenv("WEBHOOK_URL", ""),
         REPORT_DIR=Path(os.getenv("REPORT_DIR", "./reports")),
         PARSER_USER_AGENT=os.getenv("PARSER_USER_AGENT"),


### PR DESCRIPTION
## Summary
- fall back to the Replit-provided PORT environment variable when WEBAPP_PORT is unset
- ensure the server keeps using the resolved WEBAPP_PORT value
- remove the unused 8080 port mapping from .replit so expected ports match

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ad1d4f9083208aa520b7fee985b0