### PR TITLE
Fix future import placement in errors module

### DIFF
--- a/app/utils/errors.py
+++ b/app/utils/errors.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from __future__ import annotations
-
-from __future__ import annotations
-
-import asyncio
 from dataclasses import dataclass
 
 TIMEOUT_MESSAGE = "⏱️ Площадка отвечает медленно. Попробуйте ещё раз через пару минут."


### PR DESCRIPTION
## Summary
- ensure `from __future__ import annotations` is the first executable line in `app/utils/errors.py`
- remove duplicated future import statements introduced near the top of the module

## Testing
- python - <<'PY'
import compileall, sys
ok = compileall.compile_dir('app', force=True, quiet=1)
sys.exit(0 if ok else 1)
PY
- python -m app.run --check-imports-only *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_68d51c490b50832096adf27d3e2a53f7