### PR TITLE
Improve report delivery robustness and callback handling

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -5,6 +5,8 @@ import json
 import logging
 import math
 import os
+import shutil
+import time
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -17,7 +19,7 @@ from aiogram.types import (
     InputFile,
     ReplyKeyboardRemove,
 )
-from aiogram.utils.exceptions import MessageCantBeEdited, MessageNotModified
+from aiogram.utils.exceptions import BadRequest, MessageCantBeEdited, MessageNotModified
 
 # анти-спам / занятость пользователя
 from ..middlewares.busy import BUSY_TEXT, clear_busy, is_busy, set_busy
@@ -43,6 +45,7 @@ from app.utils.errors import (
     user_message_for_no_data,
 )
 from app.utils.progress import Progress, ProgressStep
+from app.utils.report_sender import SendReportResult, send_report
 from app.utils.normalize import normalize_city, normalize_role
 
 # Кеш последнего «сомнительного» запроса: user_id -> (query, city, overrides)
@@ -55,7 +58,7 @@ PROGRESS_STEPS = (
     ProgressStep("normalize", "нормализация…"),
     ProgressStep("write_xlsx", "сбор XLSX…"),
 )
-PROGRESS_SUCCESS_TEXT = "✅ Готово"
+PROGRESS_SUCCESS_TEXT = "Готово ✅"
 PROGRESS_FAILURE_PREFIX = "❌ Не получилось…"
 
 _DIAG_ENV_KEYS = [
@@ -194,6 +197,75 @@ async def _send_diagnostic_bundle_if_needed(
             )
 
 
+def _update_ui_meta(
+    result: parser_adapter.RunReportResult | None,
+    *,
+    ack_sent: bool | None,
+    progress_strategy: str | None,
+    report_path: Path | None,
+    send_error: str | None = None,
+) -> None:
+    if not result or not result.meta:
+        return
+
+    ui_payload: dict[str, object] = {
+        "ack_sent": bool(ack_sent) if ack_sent is not None else False,
+        "progress_strategy": progress_strategy or "edit",
+        "report_path": str(report_path) if report_path else None,
+    }
+    if send_error:
+        ui_payload["send_error"] = send_error
+
+    result.meta["ui"] = {k: v for k, v in ui_payload.items() if v is not None}
+
+    bundle_path = getattr(result, "bundle_path", None)
+    if not bundle_path:
+        return
+    bundle_dir = bundle_path.with_suffix("")
+    meta_path = bundle_dir / "meta.json"
+    if not meta_path.exists():
+        return
+    try:
+        try:
+            meta_data = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            meta_data = {}
+        meta_data["ui"] = result.meta["ui"]
+        meta_path.write_text(
+            json.dumps(meta_data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        shutil.make_archive(str(bundle_dir), "zip", root_dir=bundle_dir, base_dir=".")
+    except Exception as exc:  # pragma: no cover - diagnostics best effort
+        log_event(
+            "diagnostic_meta_update_failed",
+            level="WARN",
+            bundle=str(bundle_path),
+            err=str(exc),
+        )
+
+
+async def _cleanup_inline_message(message: types.Message) -> None:
+    try:
+        await message.edit_reply_markup(reply_markup=None)
+    except MessageNotModified:
+        pass
+    except (MessageCantBeEdited, BadRequest) as exc:
+        log_event(
+            "ui.cleanup_failed",
+            level="WARN",
+            err=str(exc),
+            reason="remove_inline_markup",
+        )
+    except Exception as exc:  # pragma: no cover - UI cleanup best effort
+        log_event(
+            "ui.cleanup_failed",
+            level="WARN",
+            err=str(exc),
+            reason="remove_inline_markup",
+        )
+
+
 class ReportProgressTracker:
     def __init__(self, progress: Progress, *, has_filter: bool):
         self._progress = progress
@@ -202,6 +274,10 @@ class ReportProgressTracker:
     @property
     def progress(self) -> Progress:
         return self._progress
+
+    @property
+    def ui_strategy(self) -> str:
+        return self._progress.ui_strategy
 
     async def mark_command_ready(self) -> None:
         await self._progress.set("fetch", 10, force=True)
@@ -658,10 +734,22 @@ async def _send_report_with_analytics(
     include=None,
     exclude=None,
     reply_markup=None,
-) -> None:
+    diagnostic_path: Path | None = None,
+    diagnostic_caption: str | None = None,
+) -> SendReportResult:
     register_context(path, title=title, city=city)
     share_kb = _report_actions_keyboard()
-    await message.answer_document(InputFile(path), reply_markup=share_kb)
+    send_result = await send_report(
+        message.bot,
+        message.chat.id,
+        path,
+        reply_markup=share_kb,
+        diagnostic_path=diagnostic_path,
+        diagnostic_caption=diagnostic_caption,
+    )
+    if not send_result.ok:
+        return send_result
+
     person = getattr(message, "from_user", None)
     if person:
         chips.record_success(person.id, title, city)
@@ -698,7 +786,9 @@ async def _send_report_with_analytics(
         if activation.granted and activation.bonus:
             notify_text = f"🔥 Реферал {mention} активирован — +{activation.bonus} кредит начислен!"
         else:
-            notify_text = f"Реферал {mention} активировал триггер, но бонус не начислен (достигнут лимит)."
+            notify_text = (
+                f"Реферал {mention} активировал триггер, но бонус не начислен (достигнут лимит)."
+            )
         try:
             await message.bot.send_message(activation.inviter_id, notify_text)
         except Exception as exc:  # pragma: no cover
@@ -708,6 +798,7 @@ async def _send_report_with_analytics(
                 inviter_id=activation.inviter_id,
                 err=str(exc),
             )
+    return send_result
 
 
 async def cb_report_share(call: types.CallbackQuery):
@@ -957,7 +1048,12 @@ async def _run_parser_bypass_validation(
                 path=str(result.xlsx_path),
                 duration_ms=result.duration_ms if result else None,
             )
-            await _send_report_with_analytics(
+            correlation = None
+            if result and result.meta:
+                correlation = str(result.meta.get("correlation_id") or "").strip() or None
+            diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
+            diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
+            send_result = await _send_report_with_analytics(
                 message,
                 result.xlsx_path,
                 title=query,
@@ -965,9 +1061,38 @@ async def _run_parser_bypass_validation(
                 include=overrides.get("include"),
                 exclude=overrides.get("exclude"),
                 reply_markup=_main_menu_kb(message, user=user),
+                diagnostic_path=diagnostic_path,
+                diagnostic_caption=diagnostic_caption if diagnostic_path else None,
             )
-            if tracker:
-                await tracker.finish_success()
+            progress_strategy = tracker.ui_strategy if tracker else "edit"
+            _update_ui_meta(
+                result,
+                ack_sent=True,
+                progress_strategy=progress_strategy,
+                report_path=result.xlsx_path,
+                send_error=send_result.error_message,
+            )
+            if send_result.ok:
+                await _cleanup_inline_message(message)
+                if tracker:
+                    await tracker.finish_success()
+                complete_operation(ok=True)
+            else:
+                failure_text = (
+                    "Не удалось отправить отчёт в Telegram. Мы прислали диагностический архив,"
+                    " чтобы помочь с разбором."
+                )
+                if tracker:
+                    await tracker.fail(f"{PROGRESS_FAILURE_PREFIX} Не удалось отправить файл")
+                await message.answer(failure_text, reply_markup=_main_menu_kb(message, user=user))
+                await _send_diagnostic_bundle_if_needed(
+                    message.bot,
+                    bundle_path=result.bundle_path,
+                    correlation=correlation,
+                    user_chat_id=getattr(message.chat, "id", None),
+                    user_id=getattr(user, "id", None),
+                )
+                complete_operation(ok=False, err="send_report_failed")
     finally:
         clear_busy(uid)
 
@@ -982,6 +1107,7 @@ async def _run_with_amount(
     *,
     uid: int | None = None,
     user: types.User | None = None,
+    ui_ack_sent: bool | None = None,
 ):
     """Считает pages/per_page под нужный объём total и запускает парсер с блокировкой пользователя."""
     uid = _resolve_requester_id(message, uid)
@@ -1168,7 +1294,12 @@ async def _run_with_amount(
                 path=str(result.xlsx_path),
                 duration_ms=result.duration_ms if result else None,
             )
-            await _send_report_with_analytics(
+            correlation = None
+            if result and result.meta:
+                correlation = str(result.meta.get("correlation_id") or "").strip() or None
+            diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
+            diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
+            send_result = await _send_report_with_analytics(
                 message,
                 result.xlsx_path,
                 title=title,
@@ -1177,9 +1308,39 @@ async def _run_with_amount(
                 include=ov.get("include"),
                 exclude=ov.get("exclude"),
                 reply_markup=_main_menu_kb(message, user=user),
+                diagnostic_path=diagnostic_path,
+                diagnostic_caption=diagnostic_caption if diagnostic_path else None,
             )
-            if tracker:
-                await tracker.finish_success()
+            progress_strategy = tracker.ui_strategy if tracker else "edit"
+            ack_for_meta = ui_ack_sent if ui_ack_sent is not None else True
+            _update_ui_meta(
+                result,
+                ack_sent=ack_for_meta,
+                progress_strategy=progress_strategy,
+                report_path=result.xlsx_path,
+                send_error=send_result.error_message,
+            )
+            if send_result.ok:
+                await _cleanup_inline_message(message)
+                if tracker:
+                    await tracker.finish_success()
+                complete_operation(ok=True)
+            else:
+                failure_text = (
+                    "Не удалось отправить отчёт в Telegram. Мы прислали диагностический архив,"
+                    " чтобы помочь с разбором."
+                )
+                if tracker:
+                    await tracker.fail(f"{PROGRESS_FAILURE_PREFIX} Не удалось отправить файл")
+                await message.answer(failure_text, reply_markup=_main_menu_kb(message, user=user))
+                await _send_diagnostic_bundle_if_needed(
+                    message.bot,
+                    bundle_path=result.bundle_path,
+                    correlation=correlation,
+                    user_chat_id=getattr(message.chat, "id", None),
+                    user_id=getattr(user, "id", None),
+                )
+                complete_operation(ok=False, err="send_report_failed")
     finally:
         clear_busy(uid)
 
@@ -1384,7 +1545,12 @@ async def _run_parser(
                 if decision:
                     await _finalize_quota_usage(message, requester_id, decision)
                 _log_parse_ready(norm_title, city_to_use, ov)
-                await _send_report_with_analytics(
+                correlation = None
+                if result and result.meta:
+                    correlation = str(result.meta.get("correlation_id") or "").strip() or None
+                diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
+                diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
+                send_result = await _send_report_with_analytics(
                     message,
                     result.xlsx_path,
                     title=norm_title,
@@ -1392,9 +1558,38 @@ async def _run_parser(
                     include=ov.get("include"),
                     exclude=ov.get("exclude"),
                     reply_markup=_main_menu_kb(message, user=user),
+                    diagnostic_path=diagnostic_path,
+                    diagnostic_caption=diagnostic_caption if diagnostic_path else None,
                 )
-                if tracker:
-                    await tracker.finish_success()
+                progress_strategy = tracker.ui_strategy if tracker else "edit"
+                _update_ui_meta(
+                    result,
+                    ack_sent=True,
+                    progress_strategy=progress_strategy,
+                    report_path=result.xlsx_path,
+                    send_error=send_result.error_message,
+                )
+                if send_result.ok:
+                    await _cleanup_inline_message(message)
+                    if tracker:
+                        await tracker.finish_success()
+                    complete_operation(ok=True)
+                else:
+                    failure_text = (
+                        "Не удалось отправить отчёт в Telegram. Мы прислали диагностический архив,"
+                        " чтобы помочь с разбором."
+                    )
+                    if tracker:
+                        await tracker.fail(f"{PROGRESS_FAILURE_PREFIX} Не удалось отправить файл")
+                    await message.answer(failure_text, reply_markup=_main_menu_kb(message, user=user))
+                    await _send_diagnostic_bundle_if_needed(
+                        message.bot,
+                        bundle_path=result.bundle_path,
+                        correlation=correlation,
+                        user_chat_id=getattr(message.chat, "id", None),
+                        user_id=getattr(user, "id", None),
+                    )
+                    complete_operation(ok=False, err="send_report_failed")
         finally:
             clear_busy(requester_id)
         return
@@ -1715,8 +1910,32 @@ async def cb_qty(call: types.CallbackQuery):
         await call.answer(BUSY_TEXT, show_alert=False)
         return
 
+    ack_started = time.monotonic()
+    ack_sent = False
+    try:
+        await call.answer(
+            "Запускаю выгрузку… это займёт пару минут",
+            show_alert=False,
+            cache_time=1,
+        )
+        ack_sent = True
+        log_event(
+            "callback_ack_sent",
+            callback="cb_qty",
+            status="ok",
+            latency_ms=int((time.monotonic() - ack_started) * 1000),
+        )
+    except Exception as exc:
+        log_event(
+            "callback_ack_sent",
+            callback="cb_qty",
+            status="err",
+            latency_ms=int((time.monotonic() - ack_started) * 1000),
+            err=str(exc),
+        )
+        log_event("callback_ack_failed", callback="cb_qty", err=str(exc))
+
     payload = _PENDING_QTY.get(call.from_user.id)
-    await call.answer()
     if not payload:
         await call.message.answer("Не нашёл предыдущий запрос. Введи должность ещё раз:")
         await ParseForm.waiting_query.set()
@@ -1749,6 +1968,7 @@ async def cb_qty(call: types.CallbackQuery):
         total,
         uid=call.from_user.id,
         user=call.from_user,
+        ui_ack_sent=ack_sent,
     )
 
 
@@ -1759,7 +1979,24 @@ async def cb_preview(call: types.CallbackQuery):
         await call.answer(BUSY_TEXT, show_alert=False)
         return
 
-    await call.answer("Готовлю превью…", show_alert=False)
+    ack_started = time.monotonic()
+    try:
+        await call.answer("Готовлю превью…", show_alert=False, cache_time=1)
+        log_event(
+            "callback_ack_sent",
+            callback="cb_preview",
+            status="ok",
+            latency_ms=int((time.monotonic() - ack_started) * 1000),
+        )
+    except Exception as exc:
+        log_event(
+            "callback_ack_sent",
+            callback="cb_preview",
+            status="err",
+            latency_ms=int((time.monotonic() - ack_started) * 1000),
+            err=str(exc),
+        )
+        log_event("callback_ack_failed", callback="cb_preview", err=str(exc))
 
     progress: Progress | None = None
     invalid_arguments: str | None = None
@@ -2068,6 +2305,7 @@ async def cb_resume_yes(call: types.CallbackQuery):
             request.total,
             uid=call.from_user.id,
             user=call.from_user,
+            ui_ack_sent=True,
         )
     elif request.kind == "direct":
         await _run_parser(

--- a/app/utils/progress.py
+++ b/app/utils/progress.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass
 from typing import Iterable, Sequence
 
 from aiogram import Bot
-from aiogram.utils.exceptions import MessageCantBeEdited, MessageNotModified
+from aiogram.utils.exceptions import (
+    BadRequest,
+    MessageCantBeEdited,
+    MessageNotModified,
+    RetryAfter,
+)
 
 from app.utils.logging import log_event
 
@@ -43,10 +48,15 @@ class Progress:
         self._last_percent: int = 0
         self._last_update_ts: float = 0.0
         self._closed = False
+        self._ui_strategy: str = "edit"
 
     @property
     def last_step(self) -> str | None:
         return self._last_step
+
+    @property
+    def ui_strategy(self) -> str:
+        return self._ui_strategy
 
     @classmethod
     async def create(
@@ -83,10 +93,11 @@ class Progress:
         inst._last_percent = initial_percent
         inst._last_update_ts = time.monotonic()
         log_event(
-            "progress.create",
+            "progress.start",
             mode=mode,
             progress_step=initial_step,
             percent=initial_percent,
+            ui_action="send",
         )
         return inst
 
@@ -111,19 +122,7 @@ class Progress:
             return
         self._last_update_ts = now
         text = self._compose_current()
-        try:
-            await self._bot.edit_message_text(text, self._chat_id, self._message_id)
-        except (MessageNotModified, MessageCantBeEdited):
-            return
-        except Exception:  # pragma: no cover - best effort
-            return
-        log_event(
-            "progress.update",
-            mode=self._mode,
-            progress_step=step_name,
-            percent=percent,
-            extra=extra_text,
-        )
+        await self._deliver(text, step_name, percent, extra_text=extra_text)
 
     async def show_retry(self, attempt: int, total: int) -> None:
         if self._closed:
@@ -154,20 +153,20 @@ class Progress:
             self._last_step = self._last_step or "complete"
             self._last_percent = 100
         final_text = text
-        try:
-            await self._bot.edit_message_text(final_text, self._chat_id, self._message_id)
-        except (MessageNotModified, MessageCantBeEdited):
-            pass
-        except Exception:  # pragma: no cover - best effort
-            pass
-        else:
-            log_event(
-                "progress.close",
-                mode=self._mode,
-                progress_step=self._last_step,
-                percent=self._last_percent,
-                ok=ok,
-            )
+        action = await self._deliver(
+            final_text,
+            self._last_step or "complete",
+            self._last_percent,
+            allow_skip_logging=False,
+        )
+        log_event(
+            "progress.close",
+            mode=self._mode,
+            progress_step=self._last_step,
+            percent=self._last_percent,
+            ok=ok,
+            ui_action=action,
+        )
         if ok and delete_after:
             asyncio.create_task(self._delete_later(delete_after))
 
@@ -179,12 +178,7 @@ class Progress:
             return
         self._last_update_ts = now
         text = self._compose_current()
-        try:
-            await self._bot.edit_message_text(text, self._chat_id, self._message_id)
-        except (MessageNotModified, MessageCantBeEdited):
-            return
-        except Exception:  # pragma: no cover - best effort
-            return
+        await self._deliver(text, self._last_step or "unknown", self._last_percent)
 
     def _compose_current(self) -> str:
         return self._compose_text(
@@ -195,6 +189,80 @@ class Progress:
             extra=self._extra_text,
             retry_text=self._retry_text,
         )
+
+    async def _deliver(
+        self,
+        text: str,
+        step_name: str,
+        percent: int,
+        *,
+        extra_text: str | None = None,
+        allow_skip_logging: bool = True,
+    ) -> str:
+        """Try to update progress message, falling back to sending a new one."""
+
+        payload = {
+            "mode": self._mode,
+            "progress_step": step_name,
+            "percent": percent,
+            "extra": extra_text,
+        }
+
+        try:
+            await self._bot.edit_message_text(text, self._chat_id, self._message_id)
+        except MessageNotModified:
+            if allow_skip_logging:
+                log_event("progress.update", ui_action="skip", **payload)
+            return "skip"
+        except RetryAfter as exc:  # pragma: no cover - network timing dependant
+            await asyncio.sleep(getattr(exc, "timeout", 1))
+            return await self._deliver(
+                text,
+                step_name,
+                percent,
+                extra_text=extra_text,
+                allow_skip_logging=allow_skip_logging,
+            )
+        except (MessageCantBeEdited, BadRequest) as exc:
+            if isinstance(exc, BadRequest) and _is_message_not_modified_error(exc):
+                if allow_skip_logging:
+                    log_event("progress.update", ui_action="skip", **payload)
+                return "skip"
+            if isinstance(exc, BadRequest) and not _should_fallback_on_bad_request(exc):
+                if allow_skip_logging:
+                    log_event(
+                        "progress.update",
+                        ui_action="skip",
+                        err=str(exc),
+                        **payload,
+                    )
+                return "skip"
+            message = await self._bot.send_message(self._chat_id, text)
+            self._message_id = message.message_id
+            self._ui_strategy = "send"
+            log_event("progress.update", ui_action="send", **payload)
+            return "send"
+        except Exception as exc:  # pragma: no cover - best effort
+            try:
+                message = await self._bot.send_message(self._chat_id, text)
+            except Exception:  # pragma: no cover - best effort
+                if allow_skip_logging:
+                    log_event(
+                        "progress.update",
+                        ui_action="skip",
+                        err=str(exc),
+                        **payload,
+                    )
+                return "skip"
+            else:
+                self._message_id = message.message_id
+                self._ui_strategy = "send"
+                log_event("progress.update", ui_action="send", **payload)
+                return "send"
+        else:
+            log_event("progress.update", ui_action="edit", **payload)
+            return "edit"
+
 
     @staticmethod
     def _compose_text(
@@ -222,3 +290,13 @@ class Progress:
             await self._bot.delete_message(self._chat_id, self._message_id)
         except Exception:  # pragma: no cover - best effort
             pass
+
+
+def _is_message_not_modified_error(exc: BadRequest) -> bool:
+    message = str(exc).lower()
+    return "message is not modified" in message
+
+
+def _should_fallback_on_bad_request(exc: BadRequest) -> bool:
+    message = str(exc).lower()
+    return "message can't be edited" in message or "message to edit not found" in message

--- a/app/utils/report_sender.py
+++ b/app/utils/report_sender.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from aiogram import Bot, types
+from aiogram.types import InputFile
+from aiogram.utils.exceptions import NetworkError, TelegramAPIError
+
+from app.utils.logging import log_event
+
+MAX_TELEGRAM_FILE_SIZE = 45 * 1024 * 1024
+
+
+@dataclass
+class SendReportResult:
+    ok: bool
+    message: Optional[types.Message]
+    error: Optional[BaseException]
+    error_message: Optional[str]
+    size: Optional[int]
+
+
+async def send_report(
+    bot: Bot,
+    chat_id: int,
+    path: Path | str,
+    *,
+    caption: str | None = None,
+    reply_markup=None,
+    diagnostic_path: Path | None = None,
+    diagnostic_caption: str | None = None,
+) -> SendReportResult:
+    """Send a report file to Telegram with diagnostics and structured logging."""
+
+    started = time.monotonic()
+    report_path = Path(path)
+    try:
+        stat = report_path.stat()
+        size = stat.st_size
+    except OSError as exc:
+        log_event(
+            "send_report.check_failed",
+            path=str(report_path),
+            err=str(exc),
+        )
+        return SendReportResult(False, None, exc, str(exc), None)
+
+    if size <= 0:
+        log_event(
+            "send_report.check_failed",
+            path=str(report_path),
+            size=size,
+        )
+        return SendReportResult(False, None, None, "file_is_empty", size)
+
+    try:
+        with report_path.open("rb") as src:
+            input_file = InputFile(src, filename=report_path.name)
+            message = await bot.send_document(
+                chat_id,
+                input_file,
+                caption=caption,
+                reply_markup=reply_markup,
+            )
+    except (TelegramAPIError, NetworkError, TypeError, TimeoutError) as exc:
+        error_message = str(exc)
+        log_event(
+            "send_report.failed",
+            exc=error_message,
+            exc_type=type(exc).__name__,
+            size=size,
+            path=str(report_path),
+        )
+        if size > MAX_TELEGRAM_FILE_SIZE:
+            await _notify_file_too_big(
+                bot,
+                chat_id,
+                diagnostic_path=diagnostic_path,
+                diagnostic_caption=diagnostic_caption,
+            )
+        return SendReportResult(False, None, exc, error_message, size)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        error_message = str(exc)
+        log_event(
+            "send_report.failed",
+            exc=error_message,
+            exc_type=type(exc).__name__,
+            size=size,
+            path=str(report_path),
+        )
+        return SendReportResult(False, None, exc, error_message, size)
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    log_event(
+        "send_report.ok",
+        duration_ms=duration_ms,
+        size=size,
+        file_name=report_path.name,
+    )
+    return SendReportResult(True, message, None, None, size)
+
+
+async def _notify_file_too_big(
+    bot: Bot,
+    chat_id: int,
+    *,
+    diagnostic_path: Path | None,
+    diagnostic_caption: str | None,
+) -> None:
+    try:
+        await bot.send_message(chat_id, "Файл слишком большой для Telegram")
+    except Exception as exc:  # pragma: no cover - notification best effort
+        log_event(
+            "send_report.notify_failed",
+            level="WARN",
+            err=str(exc),
+            reason="file_too_big",
+        )
+
+    if diagnostic_path and diagnostic_path.exists():
+        try:
+            with diagnostic_path.open("rb") as diag_src:
+                diag_file = InputFile(diag_src, filename=diagnostic_path.name)
+                await bot.send_document(chat_id, diag_file, caption=diagnostic_caption)
+            log_event(
+                "send_report.diag_shared",
+                path=str(diagnostic_path),
+            )
+        except Exception as exc:  # pragma: no cover - diagnostics best effort
+            log_event(
+                "send_report.diag_failed",
+                level="WARN",
+                err=str(exc),
+                path=str(diagnostic_path),
+            )


### PR DESCRIPTION
## Summary
- send early callback acknowledgements, track UI telemetry, and clean up inline controls after report completion
- harden progress updates with retry/fallback logic and expose the strategy for diagnostics metadata
- add a structured send_report utility to retry-safe file delivery and attach diagnostics when Telegram rejects the XLSX

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5335ad2d88320aa1bf2772e51722c