### PR TITLE
Add delivery diagnostics and robust report sending

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -14,6 +14,7 @@ from app.storage.models import User
 from app.services import referrals as referral_service
 from app.utils.backup import make_sqlite_backup
 from app.utils.admins import is_admin
+from app.services.diagnostics import get_last_bundle
 from app.utils.diag import get_last_diag_dir, zip_dir
 from app.utils.logging import log_event
 
@@ -413,27 +414,44 @@ async def cmd_diag_last(message: types.Message) -> None:
     else:
         target_id = message.chat.id
 
+    bundle = get_last_bundle(target_id)
+    if bundle and bundle.exists():
+        await message.reply_document(InputFile(bundle), caption=bundle.name)
+        log_event(
+            "diag.manual_dump",
+            ok=True,
+            chat_id=target_id,
+            path=str(bundle),
+        )
+        return
+
     try:
         diag_dir = get_last_diag_dir(target_id)
     except Exception as exc:
         await message.reply("Не удалось получить диагностику.")
-        log_event("INFO", "diag.send", ok=False, user_id=target_id, err=str(exc))
+        log_event("diag.manual_dump", ok=False, chat_id=target_id, err=str(exc))
         return
 
     if not diag_dir:
         await message.reply("Диагностики пока нет.")
-        log_event("INFO", "diag.send", ok=False, user_id=target_id)
+        log_event("diag.manual_dump", ok=False, chat_id=target_id)
         return
 
     try:
         zip_path = zip_dir(diag_dir)
     except Exception as exc:
         await message.reply("Не удалось упаковать диагностику.")
-        log_event("INFO", "diag.send", ok=False, user_id=target_id, err=str(exc), dir=str(diag_dir))
+        log_event(
+            "diag.manual_dump",
+            ok=False,
+            chat_id=target_id,
+            err=str(exc),
+            dir=str(diag_dir),
+        )
         return
 
     await message.reply_document(InputFile(zip_path), caption=diag_dir.name)
-    log_event("INFO", "diag.send", ok=True, user_id=target_id, file=str(zip_path))
+    log_event("diag.manual_dump", ok=True, chat_id=target_id, path=str(zip_path))
 
 
 # -------- регистрация --------

--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -34,6 +34,11 @@ from ..services import report_share
 from ..services import paywall
 from ..services.quota import FREE_PER_MONTH, QuotaDecision, check_quota, commit_usage
 from ..services.diagnostics import get_bundle_by_correlation, remember_bundle
+from app.services.deliver_diagnostics import (
+    DeliverDiagContext,
+    build_diag_bundle,
+    build_stack,
+)
 from app import keyboards
 from app.utils.admins import admin_ids, is_admin
 from app.utils.diag import make_diag_dir, save_text, zip_dir
@@ -100,6 +105,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 
 SEND_DIAG_BUNDLES = _env_bool("SEND_DIAG_BUNDLES", True)
+_DIAG_ENABLED = _env_bool("DIAG", False)
 _ADMIN_FORWARD_IDS = tuple(admin_ids())
 
 
@@ -109,6 +115,35 @@ def _collect_diag_env() -> str:
         value = os.getenv(key)
         lines.append(f"{key}={value if value is not None else ''}")
     return "\n".join(lines)
+
+
+def _safe_document_name(path: Path) -> tuple[str, bool]:
+    original = path.name
+    cleaned = original.strip()
+    if not cleaned or cleaned in {".", ".."}:
+        return _fallback_name(path), False
+    if any(sep in cleaned for sep in ("/", "\\", "\n", "\r", "\t")):
+        return _fallback_name(path), False
+    if len(cleaned) > 120:
+        return _fallback_name(path), False
+    return cleaned, True
+
+
+def _fallback_name(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return "report.csv"
+    return "report.xlsx"
+
+
+def _extract_correlation_from_bundle(path: Path | None) -> str | None:
+    if not path:
+        return None
+    stem = path.stem
+    if stem.startswith("bundle_"):
+        remainder = stem[len("bundle_") :].strip()
+        return remainder or None
+    return None
 
 
 def _save_parser_diag(
@@ -216,6 +251,58 @@ async def _send_diagnostic_bundle_if_needed(
             )
 
 
+async def _dispatch_deliver_bundle(
+    bot: Bot,
+    *,
+    bundle_path: Path,
+    correlation_id: str | None,
+    user_chat_id: int | None,
+    user_id: int | None,
+) -> None:
+    if not bundle_path.exists():
+        return
+
+    caption = (
+        "⚠️ Ошибка доставки отчёта. Диагностика во вложении. Мы уже смотрим"
+    )
+    if correlation_id:
+        caption += f" (ID: {correlation_id})"
+    targets: list[tuple[int, str]] = []
+    delivered: set[int] = set()
+
+    if user_chat_id is not None:
+        targets.append((user_chat_id, "user"))
+        delivered.add(user_chat_id)
+
+    for admin_id in _ADMIN_FORWARD_IDS:
+        if admin_id == user_id or admin_id in delivered:
+            continue
+        targets.append((admin_id, "admin"))
+        delivered.add(admin_id)
+
+    for chat_id, target in targets:
+        try:
+            await bot.send_document(chat_id, InputFile(bundle_path), caption=caption)
+            event_name = (
+                "diagnostic_bundle_sent_user" if target == "user" else "diagnostic_bundle_sent_admin"
+            )
+            log_event(
+                event_name,
+                chat_id=chat_id,
+                correlation_id=correlation_id,
+                path=str(bundle_path),
+            )
+        except Exception as exc:
+            log_event(
+                "diagnostic_bundle_send_failed",
+                level="WARN",
+                target=target,
+                chat_id=chat_id,
+                correlation_id=correlation_id,
+                err=str(exc),
+            )
+
+
 def _update_ui_meta(
     result: parser_adapter.RunReportResult | None,
     *,
@@ -297,6 +384,10 @@ class ReportProgressTracker:
     @property
     def ui_strategy(self) -> str:
         return self._progress.ui_strategy
+
+    @property
+    def last_percent(self) -> int | None:
+        return getattr(self._progress, "last_percent", None)
 
     async def mark_command_ready(self) -> None:
         await self._progress.set("fetch", 10, force=True)
@@ -755,6 +846,7 @@ async def _send_report_with_analytics(
     reply_markup=None,
     diagnostic_path: Path | None = None,
     diagnostic_caption: str | None = None,
+    file_name_override: str | None = None,
 ) -> SendReportResult:
     register_context(path, title=title, city=city)
     share_kb = _report_actions_keyboard()
@@ -765,6 +857,7 @@ async def _send_report_with_analytics(
         reply_markup=share_kb,
         diagnostic_path=diagnostic_path,
         diagnostic_caption=diagnostic_caption,
+        file_name=file_name_override,
     )
     if not send_result.ok:
         return send_result
@@ -1077,47 +1170,183 @@ async def _run_parser_bypass_validation(
             correlation = None
             if result and result.meta:
                 correlation = str(result.meta.get("correlation_id") or "").strip() or None
-            diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
-            diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
-            send_result = await _send_report_with_analytics(
-                message,
-                result.xlsx_path,
-                title=query,
-                city=city,
-                include=overrides.get("include"),
-                exclude=overrides.get("exclude"),
-                reply_markup=_main_menu_kb(message, user=user),
-                diagnostic_path=diagnostic_path,
-                diagnostic_caption=diagnostic_caption if diagnostic_path else None,
-            )
+            report_path = Path(result.xlsx_path)
+            chat_id = getattr(message.chat, "id", None)
+            user_id = getattr(user, "id", None)
+            report_size: int | None = None
+            send_error_message: str | None = None
+            ack_sent = False
+            deliver_status = "fail"
+            safe_name, name_ok = _safe_document_name(report_path)
             progress_strategy = tracker.ui_strategy if tracker else "edit"
-            _update_ui_meta(
-                result,
-                ack_sent=True,
-                progress_strategy=progress_strategy,
-                report_path=result.xlsx_path,
-                send_error=send_result.error_message,
-            )
-            if send_result.ok:
+
+            try:
+                if report_path.exists():
+                    try:
+                        report_size = report_path.stat().st_size
+                    except OSError:
+                        report_size = None
+
+                started_payload = {
+                    "correlation_id": correlation,
+                    "chat_id": chat_id,
+                    "path": str(report_path),
+                    "file_name": safe_name if safe_name else report_path.name,
+                }
+                if report_size is not None:
+                    started_payload["size_bytes"] = report_size
+                if _DIAG_ENABLED:
+                    started_payload["cmd_line"] = (result.meta or {}).get("command_line") if result else None
+                    started_payload["progress_last_percent"] = (
+                        tracker.last_percent if tracker else None
+                    )
+                log_event(
+                    "deliver.started",
+                    **{k: v for k, v in started_payload.items() if v is not None},
+                )
+
+                if not report_path.exists():
+                    raise FileNotFoundError("report_file_missing")
+
+                if report_size is None:
+                    report_size = report_path.stat().st_size
+
+                if report_size <= 0:
+                    raise ValueError("report_file_empty")
+
+                if not name_ok:
+                    log_event(
+                        "deliver.file_name_adjusted",
+                        correlation_id=correlation,
+                        chat_id=chat_id,
+                        original=report_path.name,
+                        new=safe_name,
+                    )
+
+                diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
+                diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
+
+                send_result = await _send_report_with_analytics(
+                    message,
+                    result.xlsx_path,
+                    title=query,
+                    city=city,
+                    include=overrides.get("include"),
+                    exclude=overrides.get("exclude"),
+                    reply_markup=_main_menu_kb(message, user=user),
+                    diagnostic_path=diagnostic_path,
+                    diagnostic_caption=diagnostic_caption if diagnostic_path else None,
+                    file_name_override=safe_name,
+                )
+                ack_sent = True
+                send_error_message = send_result.error_message
+
+                if not send_result.ok:
+                    raise RuntimeError(send_result.error_message or "send_report_failed")
+
                 await _cleanup_inline_message(message)
                 if tracker:
                     await tracker.finish_success()
                 complete_operation(ok=True)
-            else:
-                failure_text = (
-                    "Не получилось отправить файл. Я приложил диагностический ZIP и уведомил поддержку."
+                deliver_status = "ok"
+            except Exception as exc:
+                deliver_status = "fail"
+                stack_full = build_stack(exc)
+                stack_lines = [line for line in stack_full.strip().splitlines() if line.strip()]
+                stack_short = stack_lines[-1] if stack_lines else type(exc).__name__
+                fail_payload = {
+                    "correlation_id": correlation,
+                    "chat_id": chat_id,
+                    "path": str(report_path),
+                    "size_bytes": report_size,
+                    "exception_type": type(exc).__name__,
+                    "message": str(exc),
+                    "stack_short": stack_short,
+                }
+                if _DIAG_ENABLED:
+                    fail_payload["cmd_line"] = (result.meta or {}).get("command_line") if result else None
+                    fail_payload["progress_last_percent"] = (
+                        tracker.last_percent if tracker else None
+                    )
+                log_event(
+                    "deliver.fail",
+                    level="ERROR",
+                    **{k: v for k, v in fail_payload.items() if v is not None},
                 )
+
+                if send_error_message is None:
+                    send_error_message = str(exc)
+
                 if tracker:
-                    await tracker.fail(f"{PROGRESS_FAILURE_PREFIX} Не удалось отправить файл")
-                await message.answer(failure_text, reply_markup=_main_menu_kb(message, user=user))
-                await _send_diagnostic_bundle_if_needed(
-                    message.bot,
-                    bundle_path=result.bundle_path,
-                    correlation=correlation,
-                    user_chat_id=getattr(message.chat, "id", None),
-                    user_id=getattr(user, "id", None),
+                    await tracker.fail(
+                        f"{PROGRESS_FAILURE_PREFIX} Ошибка доставки файла"
+                    )
+
+                failure_text = "Не получилось… прикладываю диагностику, команда уже уведомлена"
+                await message.answer(
+                    failure_text,
+                    reply_markup=_main_menu_kb(message, user=user),
                 )
+
+                bundle_path: Path | None = None
+                bundle_correlation: str | None = None
+                try:
+                    context = DeliverDiagContext(
+                        user_id=user_id,
+                        username=getattr(user, "username", None),
+                        chat_id=chat_id,
+                        exception_type=type(exc).__name__,
+                        exception_message=str(exc),
+                        stack=stack_full,
+                        xlsx_path=report_path,
+                        xlsx_size=report_size,
+                        csv_path=result.csv_path if result else None,
+                        stdout_path=result.stdout_path if result else None,
+                        stderr_path=result.stderr_path if result else None,
+                        cmd_line=(result.meta or {}).get("command_line") if result else None,
+                        progress_last_percent=tracker.last_percent if tracker else None,
+                    )
+                    bundle_path = build_diag_bundle(correlation, context)
+                    bundle_correlation = _extract_correlation_from_bundle(bundle_path) or correlation
+                    remember_bundle(
+                        chat_id=chat_id,
+                        correlation_id=bundle_correlation,
+                        bundle_path=bundle_path,
+                    )
+                    if bundle_correlation:
+                        correlation = bundle_correlation
+                except Exception as bundle_exc:
+                    log_event(
+                        "diagnostic_bundle_failed",
+                        level="ERROR",
+                        correlation_id=correlation,
+                        path=str(report_path),
+                        err=str(bundle_exc),
+                    )
+                else:
+                    await _dispatch_deliver_bundle(
+                        message.bot,
+                        bundle_path=bundle_path,
+                        correlation_id=bundle_correlation or correlation,
+                        user_chat_id=chat_id,
+                        user_id=user_id,
+                    )
+
                 complete_operation(ok=False, err="send_report_failed")
+            finally:
+                _update_ui_meta(
+                    result,
+                    ack_sent=ack_sent,
+                    progress_strategy=progress_strategy,
+                    report_path=result.xlsx_path,
+                    send_error=send_error_message,
+                )
+                log_event(
+                    "deliver.done",
+                    correlation_id=correlation,
+                    status="ok" if deliver_status == "ok" else "fail",
+                    chat_id=chat_id,
+                )
     finally:
         clear_busy(uid)
 

--- a/app/services/deliver_diagnostics.py
+++ b/app/services/deliver_diagnostics.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import traceback
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from aiogram import __version__ as aiogram_version
+
+from app.utils.logging import log_event
+
+STD_TAIL_BYTES = 4096
+CSV_PREVIEW_LINES = 10
+
+
+@dataclass
+class DeliverDiagContext:
+    user_id: int | None
+    username: str | None
+    chat_id: int | None
+    exception_type: str
+    exception_message: str
+    stack: str
+    xlsx_path: Path | None
+    xlsx_size: int | None
+    csv_path: Path | None
+    stdout_path: Path | None
+    stderr_path: Path | None
+    cmd_line: str | None
+    progress_last_percent: int | None
+
+
+def build_diag_bundle(correlation_id: str | None, context: DeliverDiagContext) -> Path:
+    """Build diagnostic bundle for delivery failures and return archive path."""
+
+    safe_correlation = _sanitize_correlation(correlation_id)
+    user_dir = str(context.user_id) if context.user_id is not None else "unknown"
+    base_dir = Path("reports") / user_dir / f"bundle_{safe_correlation}"
+
+    bundle_dir = _ensure_unique_dir(base_dir)
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    meta_path = bundle_dir / "meta.json"
+    env_path = bundle_dir / "env.txt"
+    stdout_path = bundle_dir / "stdout.txt"
+    stderr_path = bundle_dir / "stderr.txt"
+    head_tail_path = bundle_dir / "head_tail.txt"
+
+    ts_iso = datetime.now(timezone.utc).isoformat()
+
+    meta_payload = {
+        "correlation_id": safe_correlation,
+        "step": "deliver",
+        "exception_type": context.exception_type,
+        "exception_message": context.exception_message,
+        "stack": context.stack,
+        "xlsx_path": str(context.xlsx_path) if context.xlsx_path else None,
+        "xlsx_size": context.xlsx_size,
+        "cmd_line": context.cmd_line,
+        "progress_last_percent": context.progress_last_percent,
+        "user": {
+            "id": context.user_id,
+            "username": context.username,
+            "chat_id": context.chat_id,
+        },
+        "ts": ts_iso,
+    }
+
+    meta_path.write_text(
+        json.dumps(meta_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    stdout_tail = _read_tail(context.stdout_path)
+    stderr_tail = _read_tail(context.stderr_path)
+    stdout_path.write_text(stdout_tail, encoding="utf-8", errors="replace")
+    stderr_path.write_text(stderr_tail, encoding="utf-8", errors="replace")
+
+    head_tail = _read_csv_head_tail(context.csv_path)
+    head_tail_path.write_text(head_tail, encoding="utf-8", errors="replace")
+
+    env_summary = _collect_env_summary()
+    env_path.write_text(env_summary, encoding="utf-8", errors="replace")
+
+    archive_path = Path(
+        shutil.make_archive(str(bundle_dir), "zip", root_dir=bundle_dir, base_dir=".")
+    )
+
+    files_count = _count_files(bundle_dir)
+    size_bytes = archive_path.stat().st_size if archive_path.exists() else None
+
+    log_event(
+        "diagnostic_bundle_ready",
+        bundle_path=str(archive_path),
+        size_bytes=size_bytes,
+        files_count=files_count,
+        correlation_id=safe_correlation,
+    )
+
+    return archive_path
+
+
+def _sanitize_correlation(correlation_id: str | None) -> str:
+    if correlation_id:
+        safe = "".join(ch for ch in correlation_id if ch.isalnum() or ch in {"-", "_"})
+        if safe:
+            return safe[:64]
+    return uuid.uuid4().hex
+
+
+def _ensure_unique_dir(base_dir: Path) -> Path:
+    if not base_dir.exists():
+        return base_dir
+    suffix = 1
+    while True:
+        candidate = base_dir.with_name(f"{base_dir.name}_{suffix}")
+        if not candidate.exists():
+            return candidate
+        suffix += 1
+
+
+def _read_tail(path: Path | None) -> str:
+    if not path or not path.exists():
+        return "нет данных"
+    try:
+        with path.open("rb") as src:
+            src.seek(0, os.SEEK_END)
+            file_size = src.tell()
+            offset = max(file_size - STD_TAIL_BYTES, 0)
+            src.seek(offset, os.SEEK_SET)
+            data = src.read().decode("utf-8", errors="replace")
+            if offset > 0:
+                return f"…tail from byte {offset}\n" + data
+            return data or "нет данных"
+    except OSError as exc:
+        return f"не удалось прочитать: {exc}"
+
+
+def _read_csv_head_tail(path: Path | None) -> str:
+    if not path or not path.exists():
+        return "нет данных"
+
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as src:
+            head: list[str] = []
+            tail: list[str] = []
+            for idx, line in enumerate(src):
+                if idx < CSV_PREVIEW_LINES:
+                    head.append(line.rstrip("\n"))
+                tail.append(line.rstrip("\n"))
+                if len(tail) > CSV_PREVIEW_LINES:
+                    tail.pop(0)
+    except OSError as exc:
+        return f"не удалось прочитать csv: {exc}"
+
+    lines: list[str] = []
+    lines.append("=== HEAD ===")
+    lines.extend(head or ["нет данных"])
+    lines.append("=== TAIL ===")
+    lines.extend(tail or ["нет данных"])
+    return "\n".join(lines)
+
+
+def _collect_env_summary() -> str:
+    env_lines: list[str] = []
+    env_lines.append(f"MODE={_safe_env_value(os.getenv('MODE'))}")
+    env_lines.append(f"RETURN_URL_BASE={_safe_env_value(os.getenv('RETURN_URL_BASE'))}")
+    webhook = _mask_webhook(os.getenv("WEBHOOK_URL"))
+    env_lines.append(f"WEBHOOK_URL={webhook}")
+    env_lines.append(f"PYTHON_VERSION={sys.version.split()[0]}")
+    env_lines.append(f"AIROGRAM_VERSION={aiogram_version}")
+    return "\n".join(env_lines)
+
+
+def _safe_env_value(value: str | None) -> str:
+    if not value:
+        return ""
+    if len(value) > 256:
+        return value[:252] + "…"
+    return value
+
+
+def _mask_webhook(value: str | None) -> str:
+    if not value:
+        return ""
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(value)
+        if parsed.netloc:
+            return parsed.netloc
+        return parsed.path or value
+    except Exception:
+        return value
+
+
+def _count_files(path: Path) -> int:
+    count = 0
+    for _ in _iter_files(path):
+        count += 1
+    return count
+
+
+def _iter_files(path: Path) -> Iterable[Path]:
+    for entry in path.iterdir():
+        if entry.is_dir():
+            yield from _iter_files(entry)
+        else:
+            yield entry
+
+
+def build_stack(exception: BaseException) -> str:
+    return "".join(
+        traceback.format_exception(type(exception), exception, exception.__traceback__)
+    )
+

--- a/app/utils/progress.py
+++ b/app/utils/progress.py
@@ -58,6 +58,10 @@ class Progress:
     def ui_strategy(self) -> str:
         return self._ui_strategy
 
+    @property
+    def last_percent(self) -> int:
+        return self._last_percent
+
     @classmethod
     async def create(
         cls,

--- a/app/utils/report_sender.py
+++ b/app/utils/report_sender.py
@@ -32,6 +32,7 @@ async def send_report(
     reply_markup=None,
     diagnostic_path: Path | None = None,
     diagnostic_caption: str | None = None,
+    file_name: str | None = None,
 ) -> SendReportResult:
     """Send a report file to Telegram with diagnostics and structured logging."""
 
@@ -62,7 +63,8 @@ async def send_report(
 
     try:
         with report_path.open("rb") as src:
-            input_file = InputFile(src, filename=report_path.name)
+            resolved_name = _resolve_file_name(report_path, file_name)
+            input_file = InputFile(src, filename=resolved_name)
             message = await bot.send_document(
                 chat_id,
                 input_file,
@@ -106,6 +108,21 @@ async def send_report(
         path=str(report_path),
     )
     return SendReportResult(True, message, None, None, size)
+
+
+def _resolve_file_name(report_path: Path, override: str | None) -> str:
+    candidate = (override or report_path.name or "").strip()
+    if not candidate or candidate in {".", ".."}:
+        return _fallback(report_path)
+    if any(sep in candidate for sep in ("/", "\\", "\n", "\r", "\t")):
+        return _fallback(report_path)
+    if len(candidate) > 120:
+        return _fallback(report_path)
+    return candidate
+
+
+def _fallback(path: Path) -> str:
+    return "report.csv" if path.suffix.lower() == ".csv" else "report.xlsx"
 
 
 async def _notify_file_too_big(


### PR DESCRIPTION
## Summary
- add a delivery diagnostics builder that packages meta, logs, CSV previews, and env info into a ZIP bundle with structured logging
- wrap the final report delivery path with guarded logging, safe filename checks, diagnostics dispatch, and DIAG-driven verbosity
- sanitize report filenames, expose progress percentages, and let admins fetch the latest diagnostic bundle via /diag_last

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d54305f7308320bda4614cf1c3380d