### PR TITLE
Add structured diagnostics for XLSX delivery

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -52,6 +52,7 @@ from app.utils.errors import (
 )
 from app.utils.progress import Progress, ProgressStep
 from app.utils.report_sender import SendReportResult, send_report
+from app.utils.xlsx_diagnostics import collect_xlsx_diagnostics
 from app.utils.normalize import normalize_city, normalize_role
 
 # Кеш последнего «сомнительного» запроса: user_id -> (query, city, overrides)
@@ -1179,14 +1180,13 @@ async def _run_parser_bypass_validation(
             deliver_status = "fail"
             safe_name, name_ok = _safe_document_name(report_path)
             progress_strategy = tracker.ui_strategy if tracker else "edit"
+            diag_snapshot = collect_xlsx_diagnostics(report_path)
+            diag_payload = diag_snapshot.to_event_payload()
+            if diag_snapshot.size_bytes is not None:
+                report_size = diag_snapshot.size_bytes
+            send_result: SendReportResult | None = None
 
             try:
-                if report_path.exists():
-                    try:
-                        report_size = report_path.stat().st_size
-                    except OSError:
-                        report_size = None
-
                 started_payload = {
                     "correlation_id": correlation,
                     "chat_id": chat_id,
@@ -1195,6 +1195,7 @@ async def _run_parser_bypass_validation(
                 }
                 if report_size is not None:
                     started_payload["size_bytes"] = report_size
+                started_payload["diagnostics"] = diag_payload
                 if _DIAG_ENABLED:
                     started_payload["cmd_line"] = (result.meta or {}).get("command_line") if result else None
                     started_payload["progress_last_percent"] = (
@@ -1210,6 +1211,10 @@ async def _run_parser_bypass_validation(
 
                 if report_size is None:
                     report_size = report_path.stat().st_size
+                    diag_snapshot = collect_xlsx_diagnostics(report_path)
+                    diag_payload = diag_snapshot.to_event_payload()
+                    if diag_snapshot.size_bytes is not None:
+                        report_size = diag_snapshot.size_bytes
 
                 if report_size <= 0:
                     raise ValueError("report_file_empty")
@@ -1240,6 +1245,11 @@ async def _run_parser_bypass_validation(
                 )
                 ack_sent = True
                 send_error_message = send_result.error_message
+                if send_result.size is not None:
+                    report_size = send_result.size
+                if send_result.diagnostics:
+                    diag_snapshot = send_result.diagnostics
+                    diag_payload = diag_snapshot.to_event_payload()
 
                 if not send_result.ok:
                     log_event(
@@ -1253,6 +1263,7 @@ async def _run_parser_bypass_validation(
                         if send_result.error
                         else None,
                         error_message=send_result.error_message,
+                        diagnostics=diag_payload,
                     )
                     raise RuntimeError(send_result.error_message or "send_report_failed")
 
@@ -1263,6 +1274,11 @@ async def _run_parser_bypass_validation(
                 deliver_status = "ok"
             except Exception as exc:
                 deliver_status = "fail"
+                if send_result and send_result.diagnostics:
+                    diag_snapshot = send_result.diagnostics
+                else:
+                    diag_snapshot = collect_xlsx_diagnostics(report_path)
+                diag_payload = diag_snapshot.to_event_payload()
                 stack_full = build_stack(exc)
                 stack_lines = [line for line in stack_full.strip().splitlines() if line.strip()]
                 stack_short = stack_lines[-1] if stack_lines else type(exc).__name__
@@ -1274,6 +1290,7 @@ async def _run_parser_bypass_validation(
                     "exception_type": type(exc).__name__,
                     "message": str(exc),
                     "stack_short": stack_short,
+                    "diagnostics": diag_payload,
                 }
                 if _DIAG_ENABLED:
                     fail_payload["cmd_line"] = (result.meta or {}).get("command_line") if result else None
@@ -1317,6 +1334,7 @@ async def _run_parser_bypass_validation(
                         stderr_path=result.stderr_path if result else None,
                         cmd_line=(result.meta or {}).get("command_line") if result else None,
                         progress_last_percent=tracker.last_percent if tracker else None,
+                        xlsx_diagnostics=diag_payload,
                     )
                     bundle_path = build_diag_bundle(correlation, context)
                     bundle_correlation = _extract_correlation_from_bundle(bundle_path) or correlation
@@ -1358,6 +1376,7 @@ async def _run_parser_bypass_validation(
                     correlation_id=correlation,
                     status="ok" if deliver_status == "ok" else "fail",
                     chat_id=chat_id,
+                    diagnostics=diag_payload,
                 )
     finally:
         clear_busy(uid)
@@ -1618,6 +1637,7 @@ async def _run_with_amount(
                 correlation = str(result.meta.get("correlation_id") or "").strip() or None
             diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
             diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
+            chat_id = getattr(message.chat, "id", None)
             send_result = await _send_report_with_analytics(
                 message,
                 result.xlsx_path,
@@ -1639,12 +1659,38 @@ async def _run_with_amount(
                 report_path=result.xlsx_path,
                 send_error=send_result.error_message,
             )
+            diag_payload = (
+                send_result.diagnostics.to_event_payload()
+                if send_result.diagnostics
+                else collect_xlsx_diagnostics(Path(result.xlsx_path)).to_event_payload()
+            )
+            log_event(
+                "deliver.done",
+                correlation_id=correlation,
+                status="ok" if send_result.ok else "fail",
+                chat_id=chat_id,
+                diagnostics=diag_payload,
+                size_bytes=send_result.size,
+            )
             if send_result.ok:
                 await _cleanup_inline_message(message)
                 if tracker_obj:
                     await tracker_obj.finish_success()
                 complete_operation(ok=True)
             else:
+                log_event(
+                    "deliver.send_report_failed",
+                    level="ERROR",
+                    correlation_id=correlation,
+                    chat_id=chat_id,
+                    path=str(result.xlsx_path),
+                    size_bytes=send_result.size,
+                    error_type=type(send_result.error).__name__
+                    if send_result.error
+                    else None,
+                    error_message=send_result.error_message,
+                    diagnostics=diag_payload,
+                )
                 failure_text = (
                     "Не получилось отправить файл. Я приложил диагностический ZIP и уведомил поддержку."
                 )
@@ -1870,6 +1916,7 @@ async def _run_parser(
                     correlation = str(result.meta.get("correlation_id") or "").strip() or None
                 diagnostic_path = result.bundle_path if SEND_DIAG_BUNDLES else None
                 diagnostic_caption = f"diag {correlation}" if correlation else "diagnostic bundle"
+                chat_id = getattr(message.chat, "id", None)
                 send_result = await _send_report_with_analytics(
                     message,
                     result.xlsx_path,
@@ -1889,12 +1936,38 @@ async def _run_parser(
                     report_path=result.xlsx_path,
                     send_error=send_result.error_message,
                 )
+                diag_payload = (
+                    send_result.diagnostics.to_event_payload()
+                    if send_result.diagnostics
+                    else collect_xlsx_diagnostics(Path(result.xlsx_path)).to_event_payload()
+                )
+                log_event(
+                    "deliver.done",
+                    correlation_id=correlation,
+                    status="ok" if send_result.ok else "fail",
+                    chat_id=chat_id,
+                    diagnostics=diag_payload,
+                    size_bytes=send_result.size,
+                )
                 if send_result.ok:
                     await _cleanup_inline_message(message)
                     if tracker:
                         await tracker.finish_success()
                     complete_operation(ok=True)
                 else:
+                    log_event(
+                        "deliver.send_report_failed",
+                        level="ERROR",
+                        correlation_id=correlation,
+                        chat_id=chat_id,
+                        path=str(result.xlsx_path),
+                        size_bytes=send_result.size,
+                        error_type=type(send_result.error).__name__
+                        if send_result.error
+                        else None,
+                        error_message=send_result.error_message,
+                        diagnostics=diag_payload,
+                    )
                     failure_text = (
                         "Не получилось отправить файл. Я приложил диагностический ZIP и уведомил поддержку."
                     )

--- a/app/services/deliver_diagnostics.py
+++ b/app/services/deliver_diagnostics.py
@@ -34,6 +34,7 @@ class DeliverDiagContext:
     stderr_path: Path | None
     cmd_line: str | None
     progress_last_percent: int | None
+    xlsx_diagnostics: dict | None = None
 
 
 def build_diag_bundle(correlation_id: str | None, context: DeliverDiagContext) -> Path:
@@ -64,6 +65,7 @@ def build_diag_bundle(correlation_id: str | None, context: DeliverDiagContext) -
         "xlsx_size": context.xlsx_size,
         "cmd_line": context.cmd_line,
         "progress_last_percent": context.progress_last_percent,
+        "xlsx_diagnostics": context.xlsx_diagnostics,
         "user": {
             "id": context.user_id,
             "username": context.username,

--- a/app/utils/report_sender.py
+++ b/app/utils/report_sender.py
@@ -10,6 +10,7 @@ from aiogram.types import InputFile
 from aiogram.utils.exceptions import NetworkError, TelegramAPIError
 
 from app.utils.logging import log_event
+from app.utils.xlsx_diagnostics import XlsxDiagnostics, collect_xlsx_diagnostics
 
 MAX_TELEGRAM_FILE_SIZE = 45 * 1024 * 1024
 
@@ -21,6 +22,7 @@ class SendReportResult:
     error: Optional[BaseException]
     error_message: Optional[str]
     size: Optional[int]
+    diagnostics: XlsxDiagnostics | None = None
 
 
 async def send_report(
@@ -38,20 +40,27 @@ async def send_report(
 
     started = time.monotonic()
     report_path = Path(path)
+    diagnostics: XlsxDiagnostics | None = None
+
     try:
         stat = report_path.stat()
         size = stat.st_size
     except OSError as exc:
         error_message = str(exc)
+        diagnostics = collect_xlsx_diagnostics(report_path)
         log_event(
             "report.send_fail",
             level="ERROR",
             stage="stat",
             path=str(report_path),
             chat_id=chat_id,
+            diagnostics=diagnostics.to_event_payload() if diagnostics else None,
             **_exception_payload(exc),
         )
-        return SendReportResult(False, None, exc, error_message, None)
+        return SendReportResult(False, None, exc, error_message, None, diagnostics)
+
+    diagnostics = collect_xlsx_diagnostics(report_path)
+    diag_payload = diagnostics.to_event_payload() if diagnostics else None
 
     log_event(
         "report.send_prepare",
@@ -62,6 +71,7 @@ async def send_report(
         exists=True,
         suffix=report_path.suffix,
         modified_ts=int(stat.st_mtime),
+        diagnostics=diag_payload,
     )
 
     if size <= 0:
@@ -74,8 +84,9 @@ async def send_report(
             size=size,
             path=str(report_path),
             chat_id=chat_id,
+            diagnostics=diag_payload,
         )
-        return SendReportResult(False, None, None, "file_is_empty", size)
+        return SendReportResult(False, None, None, "file_is_empty", size, diagnostics)
 
     try:
         with report_path.open("rb") as src:
@@ -86,6 +97,7 @@ async def send_report(
                 chat_id=chat_id,
                 file_name=resolved_name,
                 size=size,
+                diagnostics=diag_payload,
             )
             input_file = InputFile(src, filename=resolved_name)
             message = await bot.send_document(
@@ -104,6 +116,7 @@ async def send_report(
             chat_id=chat_id,
             size=size,
             file_name=file_name or report_path.name,
+            diagnostics=diag_payload,
             **_exception_payload(exc),
         )
         if size and size > MAX_TELEGRAM_FILE_SIZE:
@@ -113,6 +126,7 @@ async def send_report(
                 path=str(report_path),
                 chat_id=chat_id,
                 size=size,
+                diagnostics=diag_payload,
             )
             await _notify_file_too_big(
                 bot,
@@ -120,7 +134,7 @@ async def send_report(
                 diagnostic_path=diagnostic_path,
                 diagnostic_caption=diagnostic_caption,
             )
-        return SendReportResult(False, None, exc, error_message, size)
+        return SendReportResult(False, None, exc, error_message, size, diagnostics)
     except Exception as exc:  # pragma: no cover - defensive fallback
         error_message = str(exc)
         log_event(
@@ -131,9 +145,10 @@ async def send_report(
             chat_id=chat_id,
             size=size,
             file_name=file_name or report_path.name,
+            diagnostics=diag_payload,
             **_exception_payload(exc),
         )
-        return SendReportResult(False, None, exc, error_message, size)
+        return SendReportResult(False, None, exc, error_message, size, diagnostics)
 
     duration_ms = int((time.monotonic() - started) * 1000)
     log_event(
@@ -143,8 +158,9 @@ async def send_report(
         file_name=file_name or report_path.name,
         path=str(report_path),
         chat_id=chat_id,
+        diagnostics=diag_payload,
     )
-    return SendReportResult(True, message, None, None, size)
+    return SendReportResult(True, message, None, None, size, diagnostics)
 
 
 def _exception_payload(exc: BaseException) -> dict[str, Any]:

--- a/app/utils/xlsx_diagnostics.py
+++ b/app/utils/xlsx_diagnostics.py
@@ -1,0 +1,153 @@
+"""Utilities for collecting diagnostics about generated XLSX reports."""
+
+from __future__ import annotations
+
+import hashlib
+import stat
+import warnings
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - optional dependency is part of runtime image
+    from openpyxl import load_workbook
+except Exception:  # pragma: no cover - openpyxl may not be available in tests
+    load_workbook = None  # type: ignore[assignment]
+
+
+MAX_ZIP_ENTRIES = 20
+MAX_SHEETS = 20
+HASH_SIZE_LIMIT_MB = 50
+
+
+@dataclass(slots=True)
+class XlsxDiagnostics:
+    """Snapshot with metadata describing the XLSX file."""
+
+    path: str
+    exists: bool
+    size_bytes: int | None = None
+    modified_ts: int | None = None
+    permissions: str | None = None
+    signature_hex: str | None = None
+    sha256: str | None = None
+    is_zip: bool | None = None
+    zip_valid: bool | None = None
+    zip_entry_count: int | None = None
+    zip_entries: list[str] | None = None
+    sheet_count: int | None = None
+    sheet_names: list[str] | None = None
+    errors: list[str] = field(default_factory=list)
+
+    def add_error(self, message: str) -> None:
+        message = message.strip()
+        if message and message not in self.errors:
+            self.errors.append(message)
+
+    def to_event_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"path": self.path, "exists": self.exists}
+        optional: dict[str, Any] = {
+            "size_bytes": self.size_bytes,
+            "modified_ts": self.modified_ts,
+            "permissions": self.permissions,
+            "signature_hex": self.signature_hex,
+            "sha256": self.sha256,
+            "is_zip": self.is_zip,
+            "zip_valid": self.zip_valid,
+            "zip_entry_count": self.zip_entry_count,
+            "zip_entries": self.zip_entries,
+            "sheet_count": self.sheet_count,
+            "sheet_names": self.sheet_names,
+        }
+        for key, value in optional.items():
+            if value is not None and value != []:
+                payload[key] = value
+        if self.errors:
+            payload["errors"] = list(self.errors)
+        return payload
+
+
+def collect_xlsx_diagnostics(path: Path | str) -> XlsxDiagnostics:
+    """Collect metadata and lightweight integrity information about XLSX file."""
+
+    path_obj = Path(path)
+    diagnostics = XlsxDiagnostics(path=str(path_obj), exists=path_obj.exists())
+
+    if not diagnostics.exists:
+        diagnostics.add_error("file_not_found")
+        return diagnostics
+
+    try:
+        stat_result = path_obj.stat()
+        diagnostics.size_bytes = stat_result.st_size
+        diagnostics.modified_ts = int(stat_result.st_mtime)
+        diagnostics.permissions = oct(stat.S_IMODE(stat_result.st_mode))
+    except OSError as exc:
+        diagnostics.add_error(f"stat:{exc}")
+
+    # Read signature and optionally hash the file (bounded by size limit)
+    try:
+        file_size = diagnostics.size_bytes or path_obj.stat().st_size
+        hash_limit_bytes = HASH_SIZE_LIMIT_MB * 1024 * 1024
+        should_hash = file_size <= hash_limit_bytes
+
+        with path_obj.open("rb") as src:
+            head = src.read(16)
+            diagnostics.signature_hex = head.hex() if head else None
+            if should_hash:
+                hasher = hashlib.sha256()
+                if head:
+                    hasher.update(head)
+                for chunk in iter(lambda: src.read(65536), b""):
+                    hasher.update(chunk)
+                diagnostics.sha256 = hasher.hexdigest()
+            else:
+                diagnostics.add_error("sha256_skipped_large_file")
+    except OSError as exc:
+        diagnostics.add_error(f"read:{exc}")
+
+    try:
+        diagnostics.is_zip = zipfile.is_zipfile(path_obj)
+    except OSError as exc:
+        diagnostics.add_error(f"zipcheck:{exc}")
+
+    if diagnostics.is_zip:
+        try:
+            with zipfile.ZipFile(path_obj) as archive:
+                names = archive.namelist()
+                diagnostics.zip_entry_count = len(names)
+                diagnostics.zip_entries = names[:MAX_ZIP_ENTRIES]
+                if len(names) > MAX_ZIP_ENTRIES:
+                    diagnostics.zip_entries.append("…")
+                diagnostics.zip_valid = True
+        except zipfile.BadZipFile as exc:
+            diagnostics.zip_valid = False
+            diagnostics.add_error(f"bad_zip:{exc}")
+        except Exception as exc:  # pragma: no cover - defensive logging
+            diagnostics.zip_valid = False
+            diagnostics.add_error(f"zip_error:{exc}")
+
+    if load_workbook is None:
+        diagnostics.add_error("openpyxl_unavailable")
+        return diagnostics
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            workbook = load_workbook(path_obj, read_only=True, data_only=True)
+        try:
+            names = list(workbook.sheetnames)
+        finally:
+            workbook.close()
+        diagnostics.sheet_count = len(names)
+        diagnostics.sheet_names = names[:MAX_SHEETS]
+        if len(names) > MAX_SHEETS:
+            diagnostics.sheet_names.append("…")
+    except Exception as exc:  # pragma: no cover - workbook inspection best effort
+        diagnostics.add_error(f"openpyxl:{exc}")
+
+    return diagnostics
+
+
+__all__ = ["collect_xlsx_diagnostics", "XlsxDiagnostics"]


### PR DESCRIPTION
## Summary
- add an XLSX diagnostics helper to capture metadata, zip integrity, and workbook information for generated reports
- enrich the Telegram report sender with structured diagnostics logging and propagate the snapshot to callers
- record delivery diagnostics across parse flows and include them in failure bundles for easier investigation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5581f58808320997c53c1a0267579