### PR TITLE
Ensure server uses unified 8080 port configuration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,22 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
+
 from dotenv import load_dotenv
 
+
 load_dotenv()
+
+
+def get_runtime_port() -> int:
+    """Resolve the port that should be used by the web application."""
+
+    port_value = os.getenv("PORT") or os.getenv("WEBAPP_PORT") or "8080"
+    try:
+        return int(port_value)
+    except ValueError as exc:  # pragma: no cover - configuration error
+        raise RuntimeError("PORT/WEBAPP_PORT must be an integer") from exc
+
 
 @dataclass
 class Settings:
@@ -33,16 +46,11 @@ def _load() -> Settings:
             return default
         return value.strip().lower() in {"1", "true", "yes", "on"}
 
-    webapp_port_value = os.getenv("WEBAPP_PORT")
-    if not webapp_port_value:
-        webapp_port_value = os.getenv("PORT")
-    webapp_port = int(webapp_port_value or "8080")
-
     cfg = Settings(
         TELEGRAM_BOT_TOKEN=os.getenv("TELEGRAM_BOT_TOKEN", ""),
         MODE=os.getenv("MODE", "polling"),
         WEBAPP_HOST=os.getenv("WEBAPP_HOST", "0.0.0.0"),
-        WEBAPP_PORT=webapp_port,
+        WEBAPP_PORT=get_runtime_port(),
         WEBHOOK_URL=os.getenv("WEBHOOK_URL", ""),
         REPORT_DIR=Path(os.getenv("REPORT_DIR", "./reports")),
         PARSER_USER_AGENT=os.getenv("PARSER_USER_AGENT"),

--- a/app/handlers/admin_debug.py
+++ b/app/handlers/admin_debug.py
@@ -11,7 +11,7 @@ import aiohttp
 from aiogram import Dispatcher, types
 from aiogram.types import InputFile
 
-from app.config import settings
+from app.config import get_runtime_port, settings
 from app.services.diagnostics import get_last_bundle
 from app.utils.admins import is_admin
 from app.utils.logging import log_event
@@ -53,12 +53,10 @@ async def cmd_runtime(message: types.Message) -> None:
     if not _is_admin(message):
         return
 
-    port_env = os.getenv("PORT")
-    port = port_env or str(settings.WEBAPP_PORT)
     text = (
         "<b>runtime</b>\n"
         f"MODE: <code>{settings.MODE}</code>\n"
-        f"PORT: <code>{port}</code>\n"
+        f"PORT: <code>{get_runtime_port()}</code>\n"
         f"WEBHOOK_URL: {settings.WEBHOOK_URL or '-'}"
     )
     await message.reply(text, parse_mode="HTML")

--- a/app/run.py
+++ b/app/run.py
@@ -15,7 +15,7 @@ from .utils.logging import setup_logging
 setup_logging()
 
 from . import webhook
-from .config import settings
+from .config import get_runtime_port, settings
 from .handlers import (  # noqa: E402  (setup_logging must run before handlers)
     admin as h_admin,
     admin_debug,
@@ -83,15 +83,7 @@ bot = dp.bot
 
 
 def _resolve_listen_port() -> int:
-    port_env = os.getenv("PORT")
-    if port_env is None:
-        if settings.MODE == "webhook":
-            raise RuntimeError("PORT environment variable must be set in webhook mode")
-        return settings.WEBAPP_PORT
-    try:
-        return int(port_env)
-    except ValueError as exc:
-        raise RuntimeError("PORT environment variable must be an integer") from exc
+    return get_runtime_port()
 
 
 def _validate_webhook_url() -> None:
@@ -118,8 +110,6 @@ def main() -> None:
     listen_port = _resolve_listen_port()
     if settings.MODE == "webhook":
         _validate_webhook_url()
-    settings.WEBAPP_PORT = listen_port
-
     logger.info(
         "Final configuration: mode=%s, webhook_url=%s, port=%s",
         settings.MODE,
@@ -150,16 +140,14 @@ def main() -> None:
 
             config = uvicorn.Config(
                 webhook.app,
-                host=settings.WEBAPP_HOST,
+                host="0.0.0.0",
                 port=listen_port,
                 log_level="info",
             )
             server = uvicorn.Server(config)
-            log_event(
-                "server_start",
-                message=f"Starting server on {settings.WEBAPP_HOST}:{listen_port}",
-            )
-            logger.info("Uvicorn running on http://%s:%s", settings.WEBAPP_HOST, listen_port)
+            start_message = f"Starting server on 0.0.0.0:{listen_port}"
+            log_event("server_start", message=start_message)
+            logger.info(start_message)
             await server.serve()
         finally:
             # Only try to remove webhook if it was successfully set

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -10,7 +10,7 @@ from aiogram import Bot, Dispatcher, types
 from fastapi import FastAPI, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from .config import settings
+from .config import get_runtime_port, settings
 from .utils.logging import log_event, setup_logging
 
 
@@ -59,21 +59,15 @@ def set_dispatcher(dp: Dispatcher):
 
 @app.get("/")
 async def root_status():
-    return {
-        "status": "ok",
-        "message": "Telegram Bot Server is running",
-        "mode": settings.MODE,
-        "dispatcher_ready": _dp is not None,
-    }
+    return {"status": "ok"}
 
 
 @app.get("/health")
 async def health_check():
-    port = os.getenv("PORT") or str(settings.WEBAPP_PORT)
     return {
         "status": "ok",
         "mode": settings.MODE,
-        "port": port,
+        "port": get_runtime_port(),
         "time": datetime.now(timezone.utc).isoformat(),
     }
 


### PR DESCRIPTION
## Summary
- add a shared helper that resolves the runtime port from PORT, WEBAPP_PORT or 8080
- run the webhook server on 0.0.0.0 with the unified port and log the startup message
- expose a simple "/" health check and reuse the helper in admin diagnostics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d641173ba48320b3e0d86ff49261d1