### PR TITLE
Normalize webhook port handling for Replit deployment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,11 +33,13 @@ def _load() -> Settings:
             return default
         return value.strip().lower() in {"1", "true", "yes", "on"}
 
+    port_value = os.getenv("PORT") or os.getenv("WEBAPP_PORT") or "8080"
+
     cfg = Settings(
         TELEGRAM_BOT_TOKEN=os.getenv("TELEGRAM_BOT_TOKEN", ""),
         MODE=os.getenv("MODE", "polling"),
-        WEBAPP_HOST=os.getenv("WEBAPP_HOST", "0.0.0.0"),
-        WEBAPP_PORT=int(os.getenv("WEBAPP_PORT", "8080")),
+        WEBAPP_HOST="0.0.0.0",
+        WEBAPP_PORT=int(port_value),
         WEBHOOK_URL=os.getenv("WEBHOOK_URL", ""),
         REPORT_DIR=Path(os.getenv("REPORT_DIR", "./reports")),
         PARSER_USER_AGENT=os.getenv("PARSER_USER_AGENT"),

--- a/app/run.py
+++ b/app/run.py
@@ -107,12 +107,15 @@ def main() -> None:
             # Start the server regardless of webhook setup status
             config = uvicorn.Config(
                 webhook.app,
-                host=settings.WEBAPP_HOST,
+                host="0.0.0.0",
                 port=settings.WEBAPP_PORT,
                 log_level="info",
             )
             server = uvicorn.Server(config)
-            log_event("server_start", message=f"Starting server on {settings.WEBAPP_HOST}:{settings.WEBAPP_PORT}")
+            log_event(
+                "server_start",
+                message=f"Starting server on 0.0.0.0:{settings.WEBAPP_PORT}",
+            )
             await server.serve()
         finally:
             # Only try to remove webhook if it was successfully set

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -16,13 +16,7 @@ def set_dispatcher(dp: Dispatcher):
 
 @app.get("/")
 async def health_check():
-    """Health check endpoint for deployment verification"""
-    return {
-        "status": "ok",
-        "message": "Telegram Bot Server is running",
-        "mode": "webhook",
-        "dispatcher_ready": _dp is not None
-    }
+    return {"status": "ok"}
 
 @app.post("/webhook")
 async def handle_update(request: Request):


### PR DESCRIPTION
## Summary
- load the webhook server port from PORT, WEBAPP_PORT or 8080 and fix the host to 0.0.0.0
- start uvicorn with the normalized port and log the standardized startup message
- streamline the root healthcheck to the required {"status": "ok"} payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d644d68ba083209c6425aff068458f