### PR TITLE
Make mini analytics import resilient

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -23,7 +23,22 @@ from ..services import parser_adapter
 from ..services import referrals
 from ..services import validator  # валидация запроса
 from ..services import chips
-from ..services.mini_analytics import get_summary, register_context, render_mini_analytics
+# --- resilient mini_analytics import (never crash app on missing symbols) ---
+try:
+    from ..services import mini_analytics as _ma  # import module, not names
+    get_summary = getattr(_ma, "get_summary", lambda *a, **k: None)
+    register_context = getattr(_ma, "register_context", lambda *a, **k: None)
+    render_mini_analytics = getattr(_ma, "render_mini_analytics", lambda *a, **k: None)
+except Exception:  # any import/exec error inside module
+    def get_summary(*a, **k):
+        return None
+
+    def register_context(*a, **k):
+        return None
+
+    def render_mini_analytics(*a, **k):
+        return None
+# --- end resilient import ---
 from ..services import report_share
 from ..services import paywall
 from ..services.quota import FREE_PER_MONTH, QuotaDecision, check_quota, commit_usage

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,1 +1,0 @@
-# services package

--- a/app/services/mini_analytics.py
+++ b/app/services/mini_analytics.py
@@ -712,3 +712,17 @@ def get_summary(path: Path) -> MiniAnalyticsSummary | None:
         log.warning("mini_analytics: failed to summarize analytics for %s: %s", path, exc, exc_info=True)
         _SUMMARY_CACHE[key] = None
         return None
+
+
+# provide stable public API even if real impl above uses other names
+if "get_summary" not in globals():
+    def get_summary(*a, **k):
+        return None
+if "register_context" not in globals():
+    def register_context(*a, **k):
+        return None
+if "render_mini_analytics" not in globals():
+    def render_mini_analytics(*a, **k):
+        return None
+
+__all__ = ["get_summary", "register_context", "render_mini_analytics"]


### PR DESCRIPTION
## Summary
- replace the direct mini_analytics symbol import in the parse handler with a resilient fallback block
- ensure the mini_analytics module always exposes the expected public API via safe stubs and __all__
- add an empty services package module so package imports are reliable

## Testing
- `python - <<'PY'
from app.services import mini_analytics as ma
print("HAS:", hasattr(ma,"get_summary"), hasattr(ma,"register_context"), hasattr(ma,"render_mini_analytics"))
from app.handlers import parse as _  # должен импортироваться без ошибок
print("PARSE IMPORT OK")
PY` *(fails: ModuleNotFoundError: No module named 'aiogram' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d64d6126f083209d387dfe917d9e57