### PR TITLE
Improve bot resilience and error logging

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -23,13 +23,12 @@ from ..services import parser_adapter
 from ..services import referrals
 from ..services import validator  # валидация запроса
 from ..services import chips
-# --- resilient mini_analytics import (never crash app on missing symbols) ---
 try:
-    from ..services import mini_analytics as _ma  # import module, not names
+    from ..services import mini_analytics as _ma
     get_summary = getattr(_ma, "get_summary", lambda *a, **k: None)
     register_context = getattr(_ma, "register_context", lambda *a, **k: None)
     render_mini_analytics = getattr(_ma, "render_mini_analytics", lambda *a, **k: None)
-except Exception:  # any import/exec error inside module
+except Exception:
     def get_summary(*a, **k):
         return None
 
@@ -38,7 +37,6 @@ except Exception:  # any import/exec error inside module
 
     def render_mini_analytics(*a, **k):
         return None
-# --- end resilient import ---
 from ..services import report_share
 from ..services import paywall
 from ..services.quota import FREE_PER_MONTH, QuotaDecision, check_quota, commit_usage

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
+import traceback
+import uuid
 
 from aiogram import Dispatcher, types
 from aiogram.dispatcher import FSMContext
@@ -13,6 +16,9 @@ from app.utils.admins import is_admin
 from app.utils.logging import log_event, update_context
 
 
+logger = logging.getLogger("bot")
+
+
 # Админы и лимиты
 FREE_PER_MONTH = int(os.getenv("FREE_PER_MONTH", "3"))
 
@@ -22,73 +28,107 @@ BANNER_PATH = os.getenv("START_BANNER_PATH", "assets/start_banner_1x1.png")
 
 # ---------- /start ----------
 async def cmd_start(message: types.Message, state: FSMContext):
-    update_context(command="/start")
-    log_event("request_parsed", message="/start", command="/start")
-    try:
-        await state.finish()
-    except Exception:
-        # на случай, если состояния нет или не инициализировано
-        pass
-
-    uid = message.from_user.id
-    existing = repo.get_user(uid)
-    repo.ensure_user(uid, message.from_user.username, message.from_user.full_name)
-    ref_result = referrals.handle_start(
-        uid,
-        message.get_args() or "",
-        is_new=existing is None,
-        username=message.from_user.username,
-        full_name=message.from_user.full_name,
+    cid = uuid.uuid4().hex[:6]
+    logger.info(
+        "command_start",
+        extra={"event": "/start", "chat_id": message.chat.id, "cid": cid},
     )
-    ref_context = {
-        "status": ref_result.status,
-        "inviter_id": ref_result.inviter_id,
-        "bonus": ref_result.invitee_bonus,
-    }
-    update_context(referral=ref_context)
-
-    kb = keyboards.main_kb(is_admin=is_admin(uid))
-
-    ref_lines: list[str] = []
-    if ref_result.inviter_username:
-        ref_lines.append(f"Тебя пригласил {ref_result.inviter_username} — ему прилетит бонус после первой активности.")
-    if ref_result.invitee_bonus:
-        ref_lines.append(f"Тебе начислен приветственный бонус: +{ref_result.invitee_bonus} кредит.")
-    if ref_result.message and ref_result.status == "rejected":
-        ref_lines.append(ref_result.message)
-
-    # 1) Пробуем отправить баннер (если файл есть) с коротким капшеном
     try:
-        if os.path.exists(BANNER_PATH):
-            caption = (
-                "HR-Assist — собираю вакансии и присылаю Excel-отчёт.\n"
-                f"Нажми «🔎 Поиск». Бесплатно — {FREE_PER_MONTH} запроса в месяц."
+        update_context(command="/start")
+        log_event("request_parsed", message="/start", command="/start")
+        try:
+            await state.finish()
+        except Exception:
+            # на случай, если состояния нет или не инициализировано
+            pass
+
+        uid = message.from_user.id
+        existing = repo.get_user(uid)
+        repo.ensure_user(uid, message.from_user.username, message.from_user.full_name)
+        ref_result = referrals.handle_start(
+            uid,
+            message.get_args() or "",
+            is_new=existing is None,
+            username=message.from_user.username,
+            full_name=message.from_user.full_name,
+        )
+        ref_context = {
+            "status": ref_result.status,
+            "inviter_id": ref_result.inviter_id,
+            "bonus": ref_result.invitee_bonus,
+        }
+        update_context(referral=ref_context)
+
+        kb = keyboards.main_kb(is_admin=is_admin(uid))
+
+        ref_lines: list[str] = []
+        if ref_result.inviter_username:
+            ref_lines.append(
+                f"Тебя пригласил {ref_result.inviter_username} — ему прилетит бонус после первой активности."
             )
-            if ref_lines:
-                caption = "\n".join(ref_lines + ["", caption])
-            await message.answer_photo(InputFile(BANNER_PATH), caption=caption, reply_markup=kb)
-            return
-    except Exception:
-        # не ломаемся, просто идём на текст
-        pass
+        if ref_result.invitee_bonus:
+            ref_lines.append(
+                f"Тебе начислен приветственный бонус: +{ref_result.invitee_bonus} кредит."
+            )
+        if ref_result.message and ref_result.status == "rejected":
+            ref_lines.append(ref_result.message)
 
-    # 2) Фолбэк-текст (если баннера нет/не отправился)
-    extra = "\n".join(ref_lines)
-    if extra:
-        extra += "\n\n"
-    text = (
-        f"{extra}"
-        "Привет! Я <b>HR-Assist</b> — соберу вакансии по твоему запросу и пришлю файл Excel.\n\n"
-        "Как пользоваться:\n"
-        "1) Нажми «🔎 Поиск» — я спрошу должность и город.\n"
-        "2) Или одной командой: <code>/parse бариста; Москва</code>\n"
-        "3) Получишь .xlsx с вакансиями.\n\n"
-        f"🎁 Бесплатно — {FREE_PER_MONTH} запроса в месяц.\n"
-        "Нужно больше? Жми «💳 Купить».\n\n"
-        "Подробная помощь — <code>/help</code> (очень коротко и по делу).\n"
-        "Продвинутые настройки — <code>/advanced</code> (необязательно)."
-    )
-    await message.reply(text, reply_markup=kb, disable_web_page_preview=True)
+        # 1) Пробуем отправить баннер (если файл есть) с коротким капшеном
+        try:
+            if os.path.exists(BANNER_PATH):
+                caption = (
+                    "HR-Assist — собираю вакансии и присылаю Excel-отчёт.\n"
+                    f"Нажми «🔎 Поиск». Бесплатно — {FREE_PER_MONTH} запроса в месяц."
+                )
+                if ref_lines:
+                    caption = "\n".join(ref_lines + ["", caption])
+                await message.answer_photo(
+                    InputFile(BANNER_PATH), caption=caption, reply_markup=kb
+                )
+                return
+        except Exception:
+            # не ломаемся, просто идём на текст
+            pass
+
+        # 2) Фолбэк-текст (если баннера нет/не отправился)
+        extra = "\n".join(ref_lines)
+        if extra:
+            extra += "\n\n"
+        text = (
+            f"{extra}"
+            "Привет! Я <b>HR-Assist</b> — соберу вакансии по твоему запросу и пришлю файл Excel.\n\n"
+            "Как пользоваться:\n"
+            "1) Нажми «🔎 Поиск» — я спрошу должность и город.\n"
+            "2) Или одной командой: <code>/parse бариста; Москва</code>\n"
+            "3) Получишь .xlsx с вакансиями.\n\n"
+            f"🎁 Бесплатно — {FREE_PER_MONTH} запроса в месяц.\n"
+            "Нужно больше? Жми «💳 Купить».\n\n"
+            "Подробная помощь — <code>/help</code> (очень коротко и по делу).\n"
+            "Продвинутые настройки — <code>/advanced</code> (необязательно)."
+        )
+        await message.reply(text, reply_markup=kb, disable_web_page_preview=True)
+        return
+    except Exception as e:
+        tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+        logger.error(
+            "start_handler_failed",
+            extra={
+                "event": "exception",
+                "cid": cid,
+                "chat_id": message.chat.id,
+                "traceback": tb[:15000],
+            },
+        )
+        try:
+            await message.answer(
+                "Ой, что-то пошло не так 😕\n"
+                "Попробуйте ещё раз через минуту.\n"
+                f"ID: `{cid}`",
+                parse_mode="Markdown",
+            )
+        except Exception:
+            # даже если answer упадёт — не роняем процесс
+            pass
 
 
 # ---------- /help ----------

--- a/app/run.py
+++ b/app/run.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+import traceback
 
 import aiogram
 import aiohttp
 import uvicorn
-from aiogram import Dispatcher, executor
+from aiogram import Bot, Dispatcher, executor
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
+from aiogram.utils.exceptions import TelegramAPIError
 
 from . import webhook
 from .config import settings
@@ -32,11 +35,37 @@ from .utils.logging import (
 from .utils.telegram_logging import LoggedBot
 
 
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+logger = logging.getLogger("bot")
+
+
 def create_dispatcher() -> Dispatcher:
     setup_logging()
 
     bot = LoggedBot(token=settings.TELEGRAM_BOT_TOKEN, parse_mode="HTML")
+    Bot.set_current(bot)
     dp = Dispatcher(bot, storage=MemoryStorage())
+
+    # ---- global errors handler (aiogram v2) ----
+    @dp.errors_handler()
+    async def _global_errors_handler(update, exception):
+        # Полный стек для логов
+        tb = "".join(traceback.format_exception(type(exception), exception, exception.__traceback__))
+        exc_type = type(exception).__name__
+        if isinstance(exception, TelegramAPIError):
+            exc_type = f"TelegramAPIError:{exc_type}"
+        logger.error(
+            "unhandled_exception",
+            extra={
+                "event": "exception",
+                "update": update.to_python() if hasattr(update, "to_python") else str(update),
+                "exception_type": exc_type,
+                "traceback": tb[:15000],  # чтобы не раздуть логи
+            },
+        )
+        # Возвращаем True — чтобы aiogram не ронял процесс
+        return True
+    # -------------------------------------------
 
     dp.middleware.setup(OperationLoggerMiddleware())
     dp.middleware.setup(BusyMiddleware())
@@ -83,6 +112,8 @@ def main() -> None:
             f"(aiogram={aiogram.__version__}, aiohttp={aiohttp.__version__})"
         ),
     )
+
+    logger.info("startup_ok", extra={"event": "startup"})
 
     if settings.MODE == "polling":
         executor.start_polling(dp, skip_updates=True)

--- a/app/services/mini_analytics.py
+++ b/app/services/mini_analytics.py
@@ -23,8 +23,6 @@ _CONTEXT: dict[str, tuple[str, str]] = {}
 
 _THIN_NBSP = "\u202f"
 
-__all__ = ["get_summary", "register_context", "render_mini_analytics"]
-
 
 MINI_ANALYTICS_AVAILABLE = pd is not None and np is not None
 
@@ -714,15 +712,10 @@ def get_summary(path: Path) -> MiniAnalyticsSummary | None:
         return None
 
 
-# provide stable public API even if real impl above uses other names
 if "get_summary" not in globals():
-    def get_summary(*a, **k):
-        return None
+    def get_summary(*a, **k): return None
 if "register_context" not in globals():
-    def register_context(*a, **k):
-        return None
+    def register_context(*a, **k): return None
 if "render_mini_analytics" not in globals():
-    def render_mini_analytics(*a, **k):
-        return None
-
+    def render_mini_analytics(*a, **k): return None
 __all__ = ["get_summary", "register_context", "render_mini_analytics"]


### PR DESCRIPTION
## Summary
- add centralized aiogram error handler and bot context initialization to avoid crashes and surface full tracebacks
- harden the /start handler with structured logging, correlation IDs, and safe fallbacks for user replies
- make mini_analytics integration optional-friendly with stub exports and log startup readiness

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64f3589fc8320a1e17db21b1c249b