### PR TITLE
Stabilize webhook mode and add diagnostics

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,8 +11,10 @@ class Settings:
     MODE: str
     WEBAPP_HOST: str
     WEBAPP_PORT: int
+    WEBAPP_PORT_SOURCE: str
     WEBHOOK_URL: str
     REPORT_DIR: Path
+    BUILD_VERSION: str
     PARSER_USER_AGENT: str | None = None
     PARSER_HH_BASE: str | None = None
     PARSER_GORODRABOT_BASE: str | None = None
@@ -33,15 +35,33 @@ def _load() -> Settings:
             return default
         return value.strip().lower() in {"1", "true", "yes", "on"}
 
-    port_value = os.getenv("PORT") or os.getenv("WEBAPP_PORT") or "8080"
+    port_source = "default"
+    port_raw = os.getenv("WEBAPP_PORT")
+    if port_raw:
+        port_source = "env:WEBAPP_PORT"
+    else:
+        port_raw = os.getenv("PORT")
+        if port_raw:
+            port_source = "env:PORT"
+        else:
+            port_raw = "8090"
+
+    try:
+        port_value = int(str(port_raw).strip())
+    except (TypeError, ValueError):
+        port_source = f"{port_source}:invalid"
+        port_value = 8090
 
     cfg = Settings(
         TELEGRAM_BOT_TOKEN=os.getenv("TELEGRAM_BOT_TOKEN", ""),
         MODE=os.getenv("MODE", "polling"),
         WEBAPP_HOST="0.0.0.0",
-        WEBAPP_PORT=int(port_value),
+        WEBAPP_PORT=port_value,
+        WEBAPP_PORT_SOURCE=port_source,
         WEBHOOK_URL=os.getenv("WEBHOOK_URL", ""),
         REPORT_DIR=Path(os.getenv("REPORT_DIR", "./reports")),
+        BUILD_VERSION=os.getenv("BUILD_VERSION")
+        or os.getenv("REPLIT_RELEASE", "dev"),
         PARSER_USER_AGENT=os.getenv("PARSER_USER_AGENT"),
         PARSER_HH_BASE=os.getenv("PARSER_HH_BASE"),
         PARSER_GORODRABOT_BASE=os.getenv("PARSER_GORODRABOT_BASE"),

--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -13,6 +13,7 @@ from app.storage.models import User
 from app.services import referrals as referral_service
 from app.utils.backup import make_sqlite_backup
 from app.utils.admins import is_admin
+from app.utils.callbacks import safe_answer
 
 # --- доступ ---
 def _guard(uid: int) -> bool: return is_admin(uid)
@@ -104,7 +105,8 @@ async def admin_home(message: types.Message):
 async def cb_admin_home(call: types.CallbackQuery):
     if not _guard(call.from_user.id): return
     await _safe_edit_text(call.message, "🛠 Админ-панель", reply_markup=_kb_admin_home())
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 # -------- список пользователей --------
 async def cb_users(call: types.CallbackQuery):
@@ -113,7 +115,8 @@ async def cb_users(call: types.CallbackQuery):
     page = int(payload)
     text, kb = _users_page(page)
     await _safe_edit_text(call.message, text, reply_markup=kb)
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 # -------- карточка пользователя --------
 async def cb_user(call: types.CallbackQuery):
@@ -121,9 +124,11 @@ async def cb_user(call: types.CallbackQuery):
     _, uid = call.data.split(":")
     u = repo.get_user(int(uid))
     if not u:
-        await call.answer("Пользователь не найден", show_alert=True); return
+        await safe_answer(call, "Пользователь не найден", show_alert=True)
+        return
     await _safe_edit_text(call.message, _user_card_text(u), reply_markup=_kb_user(u), parse_mode="HTML")
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 
 def _render_referral_summary() -> tuple[str, InlineKeyboardMarkup]:
@@ -167,7 +172,8 @@ async def cb_ref_summary(call: types.CallbackQuery):
         return
     text, kb = _render_referral_summary()
     await _safe_edit_text(call.message, text, reply_markup=kb, parse_mode="HTML")
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 
 def _format_user(user: User | None) -> str:
@@ -195,7 +201,7 @@ async def cb_referral_card(call: types.CallbackQuery):
     rid_int = int(rid)
     details = referral_service.admin_referral_details(rid_int)
     if not details:
-        await call.answer("Реферал не найден", show_alert=True)
+        await safe_answer(call, "Реферал не найден", show_alert=True)
         return
     inviter = _format_user(details["inviter"])
     invitee = _format_user(details["invitee"])
@@ -213,7 +219,8 @@ async def cb_referral_card(call: types.CallbackQuery):
         text += f"Причина: {details['reason']}\n"
     text += f"Источник: {details['source']}\n"
     await _safe_edit_text(call.message, text, reply_markup=_kb_referral(rid_int), parse_mode="HTML")
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 
 async def cb_referral_activate(call: types.CallbackQuery):
@@ -221,7 +228,8 @@ async def cb_referral_activate(call: types.CallbackQuery):
         return
     _, rid = call.data.split(":")
     ok, msg = referral_service.admin_activate_referral(int(rid))
-    await call.answer(msg, show_alert=not ok)
+    if not await safe_answer(call, msg, show_alert=not ok):
+        return
     if ok:
         await cb_referral_card(call)
 
@@ -231,7 +239,8 @@ async def cb_referral_reject(call: types.CallbackQuery):
         return
     _, rid = call.data.split(":")
     ok, msg = referral_service.admin_reject_referral(int(rid), reason="manual_reject")
-    await call.answer(msg, show_alert=not ok)
+    if not await safe_answer(call, msg, show_alert=not ok):
+        return
     if ok:
         await cb_referral_card(call)
 
@@ -241,7 +250,8 @@ async def cb_unlim(call: types.CallbackQuery):
     _, uid, days = call.data.split(":")
     uid, days = int(uid), int(days)
     until = repo.set_unlimited(uid, days)
-    await call.answer("Выдан безлимит", show_alert=False)
+    if not await safe_answer(call, "Выдан безлимит", show_alert=False):
+        return
     u = repo.get_user(uid)
     await _safe_edit_text(call.message, _user_card_text(u), reply_markup=_kb_user(u), parse_mode="HTML")
 
@@ -250,7 +260,8 @@ async def cb_credit(call: types.CallbackQuery):
     _, uid, n = call.data.split(":")
     uid, n = int(uid), int(n)
     bal = repo.add_credits(uid, n)
-    await call.answer(f"+{n} кредит(ов). Баланс: {bal}", show_alert=False)
+    if not await safe_answer(call, f"+{n} кредит(ов). Баланс: {bal}", show_alert=False):
+        return
     u = repo.get_user(uid)
     await _safe_edit_text(call.message, _user_card_text(u), reply_markup=_kb_user(u), parse_mode="HTML")
 
@@ -268,7 +279,8 @@ async def cb_cast_menu(call: types.CallbackQuery):
         "Рассылка:\n— отправь текст ответом на это сообщение\n— или используй точечную по ID",
         reply_markup=kb,
     )
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 # 0) точечная из карточки пользователя (КНОПКА, которая не работала)
 async def cb_cast_user(call: types.CallbackQuery):
@@ -282,7 +294,8 @@ async def cb_cast_user(call: types.CallbackQuery):
     )
     await _safe_edit_text(call.message, prompt, parse_mode="HTML")
     _CAST_TARGETS[call.message.message_id] = uid
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 # ловим ответ на «точечная рассылка пользователю <uid>»
 async def catch_reply_cast_user(message: types.Message):
@@ -315,7 +328,8 @@ async def catch_reply_cast_user(message: types.Message):
 # 1) ответом на сообщение → всем
 async def cb_cast_all(call: types.CallbackQuery):
     if not _guard(call.from_user.id): return
-    await call.answer("Пришли текст рассылки ответом на это сообщение.")
+    if not await safe_answer(call, "Пришли текст рассылки ответом на это сообщение."):
+        return
     await _safe_edit_text(
         call.message,
         "Ответь на это сообщение текстом для рассылки всем пользователям.\nОтмена: /cancel",
@@ -356,7 +370,8 @@ async def cb_cast_prompt(call: types.CallbackQuery):
         "Отмена: /cancel",
         parse_mode="HTML",
     )
-    await call.answer()
+    if not await safe_answer(call):
+        return
 
 async def cast_cmd(message: types.Message):
     if not _guard(message.from_user.id): return
@@ -390,7 +405,7 @@ async def cb_backup(call: types.CallbackQuery):
         await call.message.reply_document(InputFile(z), caption=f"Бэкап {z.name}")
     except Exception as e:
         await call.message.reply(f"Не удалось сделать бэкап: {e}")
-    await call.answer("Готово")
+    await safe_answer(call, "Готово")
 
 # -------- регистрация --------
 def register(dp: Dispatcher):

--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -42,6 +42,7 @@ from ..services import paywall
 from ..services.quota import FREE_PER_MONTH, QuotaDecision, check_quota, commit_usage
 from app import keyboards
 from app.utils.admins import is_admin
+from app.utils.callbacks import safe_answer
 from app.utils.logging import complete_operation, log_event, update_context
 from app.utils.progress import ProgressMessage
 from app.utils.normalize import normalize_city, normalize_role
@@ -521,7 +522,8 @@ async def _send_report_with_analytics(
 
 
 async def cb_report_share(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     snapshot = report_share.get_last_report(call.from_user.id)
     if not snapshot:
         await call.message.answer("Сначала запусти поиск.")
@@ -543,22 +545,25 @@ async def cb_report_share(call: types.CallbackQuery):
 async def cb_report_share_copy(call: types.CallbackQuery):
     snapshot = report_share.get_last_report(call.from_user.id)
     if not snapshot:
-        await call.answer("Сначала запусти поиск.", show_alert=True)
+        await safe_answer(call, "Сначала запусти поиск.", show_alert=True)
         return
     me = await call.bot.get_me()
     link = report_share.build_share_link(me.username or "", call.from_user.id)
     share_text = report_share.build_share_text(snapshot, link)
-    await call.answer("Скопируй текст ниже 👇", show_alert=True)
+    if not await safe_answer(call, "Скопируй текст ниже 👇", show_alert=True):
+        return
     await call.message.answer(share_text, disable_web_page_preview=True)
 
 
 async def cb_report_again(call: types.CallbackQuery, state: FSMContext):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     await cmd_parse(call.message, state)
 
 
 async def cb_report_menu(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     kb = keyboards.main_kb(is_admin=is_admin(call.from_user.id))
     await call.message.answer("Главное меню:", reply_markup=kb)
 
@@ -981,11 +986,11 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
 
     kind = payload.get("kind")
     if kind not in {"role", "city"}:
-        await call.answer()
+        await safe_answer(call)
         return
 
     if is_busy(call.from_user.id):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
 
     token = payload.get("token")
@@ -996,7 +1001,7 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
         or session.kind != kind
         or not chips.is_active(call.from_user.id, session.kind, session.token)
     ):
-        await call.answer("Эта клавиатура устарела. Начните заново.", show_alert=False)
+        await safe_answer(call, "Эта клавиатура устарела. Начните заново.", show_alert=False)
         return
 
     action = payload.get("action")
@@ -1007,7 +1012,7 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
         except (MessageCantBeEdited, MessageNotModified):
             pass
         chips.log_click(session.kind, "more", "control", position=None, action="more")
-        await call.answer()
+        await safe_answer(call)
         return
 
     if action == "prev":
@@ -1017,14 +1022,14 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
         except (MessageCantBeEdited, MessageNotModified):
             pass
         chips.log_click(session.kind, "prev", "control", position=None, action="prev")
-        await call.answer()
+        await safe_answer(call)
         return
 
     if action == "category":
         try:
             category_index = int(payload.get("value", "-1"))
         except ValueError:
-            await call.answer("Эта клавиатура устарела. Начните заново.", show_alert=False)
+            await safe_answer(call, "Эта клавиатура устарела. Начните заново.", show_alert=False)
             return
         markup = chips.show_category(session, category_index)
         try:
@@ -1038,7 +1043,7 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
             position=category_index + 1 if category_index >= 0 else None,
             action="category",
         )
-        await call.answer()
+        await safe_answer(call)
         return
 
     if action == "back":
@@ -1048,16 +1053,16 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
         except (MessageCantBeEdited, MessageNotModified):
             pass
         chips.log_click(session.kind, "back", "control", position=None, action="back")
-        await call.answer()
+        await safe_answer(call)
         return
 
     if action == "random":
         if session.kind != "role":
-            await call.answer()
+            await safe_answer(call)
             return
         value = chips.random_role()
         if not value:
-            await call.answer("Нет доступных вариантов", show_alert=False)
+            await safe_answer(call, "Нет доступных вариантов", show_alert=False)
             return
         chips.log_click("role", value, "base", position=None, action="random")
         chips.finish_session(call.from_user.id, "role")
@@ -1065,23 +1070,24 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
             await call.message.edit_reply_markup()
         except (MessageCantBeEdited, MessageNotModified):
             pass
-        await call.answer(f"Выбрано: {value}")
+        if not await safe_answer(call, f"Выбрано: {value}"):
+            return
         await _handle_role_value(call.message, state, value, user_id=call.from_user.id)
         return
 
     if action != "pick":
-        await call.answer()
+        await safe_answer(call)
         return
 
     try:
         index = int(payload.get("value", "-1"))
     except ValueError:
-        await call.answer("Эта клавиатура устарела. Начните заново.", show_alert=False)
+        await safe_answer(call, "Эта клавиатура устарела. Начните заново.", show_alert=False)
         return
 
     candidate = chips.resolve_candidate(session, index)
     if not candidate:
-        await call.answer("Эта клавиатура устарела. Начните заново.", show_alert=False)
+        await safe_answer(call, "Эта клавиатура устарела. Начните заново.", show_alert=False)
         return
 
     chips.log_click(session.kind, candidate.value, candidate.source, position=index + 1)
@@ -1090,7 +1096,8 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
         await call.message.edit_reply_markup()
     except (MessageCantBeEdited, MessageNotModified):
         pass
-    await call.answer(f"Выбрано: {candidate.value}")
+    if not await safe_answer(call, f"Выбрано: {candidate.value}"):
+        return
 
     if session.kind == "role":
         await _handle_role_value(call.message, state, candidate.value, user_id=call.from_user.id)
@@ -1101,9 +1108,10 @@ async def cb_chip(call: types.CallbackQuery, state: FSMContext):
 # ---------- ключевые слова (include/exclude) ----------
 async def cb_kw_yes(call: types.CallbackQuery, state: FSMContext):
     if is_busy(call.from_user.id):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
-    await call.answer()
+    if not await safe_answer(call):
+        return
     update_context(dialog_step=_dialog_step("kw_prompt", "include"))
     await call.message.answer(
         "Введи слова, которые ДОЛЖНЫ встречаться (через запятую). Пример: электроника, b2b, pcb.\n"
@@ -1115,9 +1123,10 @@ async def cb_kw_yes(call: types.CallbackQuery, state: FSMContext):
 
 async def cb_kw_no(call: types.CallbackQuery, state: FSMContext):
     if is_busy(call.from_user.id):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
-    await call.answer()
+    if not await safe_answer(call):
+        return
     update_context(dialog_step=_dialog_step("kw_skip", ""))
     data = await state.get_data()
     query = data.get("query")
@@ -1166,10 +1175,11 @@ async def process_kw_exclude(message: types.Message, state: FSMContext):
 # ---------- callbacks из предупреждения / объём / превью ----------
 async def cb_parse_force(call: types.CallbackQuery, state: FSMContext):
     if is_busy(call.from_user.id):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
     payload = _WARN_CACHE.pop(call.from_user.id, None)
-    await call.answer()
+    if not await safe_answer(call):
+        return
     if not payload:
         await call.message.answer("Не нашёл последний запрос. Введи должность ещё раз:")
         await ParseForm.waiting_query.set()
@@ -1192,10 +1202,11 @@ async def cb_parse_force(call: types.CallbackQuery, state: FSMContext):
 
 async def cb_parse_fix(call: types.CallbackQuery):
     if is_busy(call.from_user.id):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
     _WARN_CACHE.pop(call.from_user.id, None)
-    await call.answer()
+    if not await safe_answer(call):
+        return
     update_context(dialog_step=_dialog_step("fix_query", ""))
     await call.message.answer("Окей! Введи должность ещё раз:", reply_markup=ReplyKeyboardRemove())
     await ParseForm.waiting_query.set()
@@ -1204,11 +1215,12 @@ async def cb_parse_fix(call: types.CallbackQuery):
 async def cb_qty(call: types.CallbackQuery):
     # если занят — просто подсказка и выходим
     if is_busy(call.from_user.id):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
 
     payload = _PENDING_QTY.get(call.from_user.id)
-    await call.answer()
+    if not await safe_answer(call):
+        return
     if not payload:
         await call.message.answer("Не нашёл предыдущий запрос. Введи должность ещё раз:")
         await ParseForm.waiting_query.set()
@@ -1242,10 +1254,11 @@ async def cb_preview(call: types.CallbackQuery):
     """Показать 5 первых совпадений без уничтожения кеша запроса."""
     uid = call.from_user.id
     if not set_busy(uid):
-        await call.answer(BUSY_TEXT, show_alert=False)
+        await safe_answer(call, BUSY_TEXT, show_alert=False)
         return
 
-    await call.answer("Готовлю превью…", show_alert=False)
+    if not await safe_answer(call, "Готовлю превью…", show_alert=False):
+        return
 
     progress: ProgressMessage | None = None
     try:
@@ -1280,7 +1293,7 @@ async def cb_preview(call: types.CallbackQuery):
         progress = await ProgressMessage.create(call.message.bot, call.message.chat.id, PREVIEW_TEMPLATE)
         _log_preview_start(title, city, overrides)
         try:
-            rows = await parser_adapter.preview_rows(
+            preview_result = await parser_adapter.preview_rows(
                 uid,
                 title,
                 city,
@@ -1288,11 +1301,16 @@ async def cb_preview(call: types.CallbackQuery):
                 include=include,
                 exclude=exclude,
             )
-        except asyncio.TimeoutError as exc:
+        except parser_adapter.DiagnosticError as exc:
             _log_preview_timeout(title, city, overrides, err=str(exc))
             if progress:
                 await progress.fail()
-            await call.message.answer("⏳ Превью не успело загрузиться. Попробуй ещё раз.")
+            await call.message.answer(
+                "Не получилось подготовить превью 😔\n"
+                "Попробуйте ещё раз позже.\n"
+                f"ID: `{exc.bundle_id}`",
+                parse_mode="Markdown",
+            )
             return
         except Exception as exc:
             _log_preview_timeout(title, city, overrides, err=str(exc))
@@ -1301,6 +1319,7 @@ async def cb_preview(call: types.CallbackQuery):
             await call.message.answer("⏳ Превью не успело загрузиться. Попробуй ещё раз.")
             return
 
+        rows = preview_result.rows
         if not rows:
             await call.message.answer("Совпадений не нашлось по текущим критериям.")
             _log_preview_ready(title, city, 0, overrides)
@@ -1363,7 +1382,8 @@ async def prompt_resume(bot: Bot, user_id: int) -> None:
 
 
 async def cb_resume_yes(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     request = paywall.consume_request(call.from_user.id)
     if not request:
         await call.message.answer(
@@ -1417,7 +1437,8 @@ async def cb_resume_yes(call: types.CallbackQuery):
 
 
 async def cb_resume_skip(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     request = paywall.get_request(call.from_user.id)
     paywall.clear_request(call.from_user.id)
     log_event("resume_skipped", message="resume skipped", args={"request": request.to_log() if request else None})

--- a/app/handlers/payments.py
+++ b/app/handlers/payments.py
@@ -6,6 +6,7 @@ from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from app import keyboards
 from app.handlers import parse
 from app.services import paywall, payments, referrals
+from app.utils.callbacks import safe_answer
 from app.utils.logging import complete_operation, log_event, update_context
 from app.utils.admins import is_admin
 
@@ -33,7 +34,7 @@ async def _start_payment_flow(call: types.CallbackQuery, pack: str) -> None:
 
     pending = paywall.get_pending_payment(call.from_user.id)
     if pending and pending.pack == pack:
-        await call.answer("Оплата уже открыта — проверь ссылку выше.")
+        await safe_answer(call, "Оплата уже открыта — проверь ссылку выше.")
         return
 
     me = await call.bot.get_me()
@@ -41,7 +42,7 @@ async def _start_payment_flow(call: types.CallbackQuery, pack: str) -> None:
         pid, url = payments.create_payment(call.from_user.id, pack, bot_username=me.username)
     except Exception as exc:
         log_event("payment_failed", level="ERROR", err=str(exc), message="create_payment failed")
-        await call.answer("Ошибка создания платежа", show_alert=True)
+        await safe_answer(call, "Ошибка создания платежа", show_alert=True)
         complete_operation(ok=False, err="payment_create_failed")
         return
 
@@ -59,7 +60,7 @@ async def _start_payment_flow(call: types.CallbackQuery, pack: str) -> None:
         reply_markup=kb,
     )
     await call.message.answer("Открыл оплату. После успешного платежа доступ появится автоматически.")
-    await call.answer()
+    await safe_answer(call)
 
 
 async def cb_create(call: types.CallbackQuery):
@@ -72,23 +73,26 @@ async def cb_create(call: types.CallbackQuery):
 async def cb_buy_pack(call: types.CallbackQuery):
     pack = _resolve_pack(call.data)
     if not pack:
-        await call.answer()
+        await safe_answer(call)
         return
     await _start_payment_flow(call, pack)
 
 
 async def cb_buy_open(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     await call.message.answer(paywall.paywall_text(), reply_markup=paywall.paywall_keyboard())
 
 
 async def cb_buy_info(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     await call.message.answer(paywall.paywall_text(), reply_markup=paywall.paywall_keyboard())
 
 
 async def cb_buy_back(call: types.CallbackQuery):
-    await call.answer()
+    if not await safe_answer(call):
+        return
     await call.message.answer(
         "Главное меню:", reply_markup=keyboards.main_kb(is_admin=is_admin(call.from_user.id))
     )
@@ -111,7 +115,7 @@ async def cb_check(call: types.CallbackQuery):
         paywall.clear_pending_payment(call.from_user.id)
     if status == "succeeded":
         await parse.prompt_resume(call.bot, call.from_user.id)
-    await call.answer()
+    await safe_answer(call)
 
 
 async def start_with_payload(message: types.Message):

--- a/app/handlers/referrals.py
+++ b/app/handlers/referrals.py
@@ -9,6 +9,7 @@ from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from app.config import settings
 from app.services import referrals
 from app.storage import repo
+from app.utils.callbacks import safe_answer
 from app.utils.logging import log_event, update_context
 
 
@@ -42,7 +43,7 @@ async def cmd_referrals(message: types.Message):
 async def cb_ref_copy(call: types.CallbackQuery):
     me = await call.bot.get_me()
     link = referrals.build_referral_link(me.username or "", call.from_user.id)
-    await call.answer(link, show_alert=True)
+    await safe_answer(call, link, show_alert=True)
 
 
 async def cmd_promo(message: types.Message):

--- a/app/run.py
+++ b/app/run.py
@@ -28,6 +28,7 @@ from .storage.db import init_db
 from .utils.logging import (
     build_audit_summary,
     complete_operation,
+    get_operation_context,
     log_event,
     set_audit_sink,
     setup_logging,
@@ -49,21 +50,30 @@ def create_dispatcher() -> Dispatcher:
     # ---- global errors handler (aiogram v2) ----
     @dp.errors_handler()
     async def _global_errors_handler(update, exception):
-        # Полный стек для логов
         tb = "".join(traceback.format_exception(type(exception), exception, exception.__traceback__))
         exc_type = type(exception).__name__
         if isinstance(exception, TelegramAPIError):
             exc_type = f"TelegramAPIError:{exc_type}"
-        logger.error(
+
+        snapshot: dict[str, object] | str
+        try:
+            snapshot = update.to_python() if hasattr(update, "to_python") else str(update)
+        except Exception:  # pragma: no cover - defensive logging
+            snapshot = str(update)
+
+        ctx = get_operation_context()
+        chat_id = getattr(ctx, "chat_id", None) if ctx else None
+
+        log_event(
             "unhandled_exception",
-            extra={
-                "event": "exception",
-                "update": update.to_python() if hasattr(update, "to_python") else str(update),
-                "exception_type": exc_type,
-                "traceback": tb[:15000],  # чтобы не раздуть логи
-            },
+            level="ERROR",
+            message=str(exception) or exc_type,
+            exception_type=exc_type,
+            traceback=tb[:15000],
+            update_snapshot=snapshot,
+            chat_id=chat_id,
         )
-        # Возвращаем True — чтобы aiogram не ронял процесс
+        complete_operation(ok=False, err=str(exception) or exc_type, force=True)
         return True
     # -------------------------------------------
 
@@ -115,6 +125,22 @@ def main() -> None:
 
     logger.info("startup_ok", extra={"event": "startup"})
 
+    health_url = f"http://0.0.0.0:{settings.WEBAPP_PORT}/health"
+    log_event(
+        "startup_banner",
+        message=(
+            f"mode={settings.MODE} webhook_url={settings.WEBHOOK_URL or '-'} "
+            f"port={settings.WEBAPP_PORT} (source={settings.WEBAPP_PORT_SOURCE}) "
+            f"health={health_url}"
+        ),
+        mode=settings.MODE,
+        webhook_url=settings.WEBHOOK_URL,
+        webapp_port=settings.WEBAPP_PORT,
+        webapp_port_source=settings.WEBAPP_PORT_SOURCE,
+        health_url=health_url,
+        build_version=settings.BUILD_VERSION,
+    )
+
     if settings.MODE == "polling":
         executor.start_polling(dp, skip_updates=True)
         return
@@ -130,7 +156,7 @@ def main() -> None:
                 webhook_setup_success = True
                 log_event("webhook_setup", message="Webhook configured successfully")
             except Exception as e:
-                log_event("webhook_setup_failed", level="WARN", 
+                log_event("webhook_setup_failed", level="WARN",
                          message=f"Initial webhook setup failed: {e}. Server will start anyway.")
                 print(f"Warning: Webhook setup failed: {e}")
                 print("The server will start anyway. You can manually set the webhook later.")

--- a/app/services/parser_adapter.py
+++ b/app/services/parser_adapter.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
-import os
-import sys
-import json
+
 import asyncio
-import subprocess
+import json
 import logging
-from pathlib import Path
-from datetime import datetime
-from typing import Awaitable, Callable, Iterable, List, Optional, Tuple
+import os
+import subprocess
+import sys
+import traceback
+import uuid
 from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple
+
+from app.utils.diagnostics import write_bundle
+from app.utils.logging import log_event
 
 log = logging.getLogger(__name__)
 
@@ -151,6 +157,7 @@ def _hh_preview_rows(query: str, area: int | None, include, exclude, rows: int) 
 
     return rows_out[:rows]
 
+
 async def preview_report(
     user_id: int,
     query: str,
@@ -159,6 +166,7 @@ async def preview_report(
     area: Optional[int] = None,
     include: Iterable[str] | str | None = None,
     exclude: Iterable[str] | str | None = None,
+    diagnostic: Dict[str, Any] | None = None,
 ) -> Optional[List[Tuple[str, str, str]]]:
     """
     Быстрое превью первых PREVIEW_ROWS карточек:
@@ -166,14 +174,40 @@ async def preview_report(
     2) Если выбран режим *first* и он неудачный — пробуем второй вариант.
     Возвращает список [(title, company, url)] или None при полном фэйле/таймауте.
     """
+    if diagnostic is not None:
+        diagnostic.clear()
+        diagnostic.update(
+            {
+                "mode": None,
+                "command": None,
+                "stdout": [],
+                "stderr": [],
+                "attempt": None,
+                "error": None,
+                "returncode": None,
+            }
+        )
+
     if not query or not city:
         return None
 
-    # локальные шорткаты
-    def _try_api():
-        return _hh_preview_rows(query, area, include, exclude, PREVIEW_ROWS)
+    def _try_api() -> Optional[List[Tuple[str, str, str]]]:
+        rows = _hh_preview_rows(query, area, include, exclude, PREVIEW_ROWS)
+        if diagnostic is not None:
+            diagnostic.update(
+                {
+                    "mode": "api",
+                    "command": None,
+                    "stdout": [],
+                    "stderr": [],
+                    "attempt": None,
+                    "error": None,
+                    "returncode": None,
+                }
+            )
+        return rows
 
-    async def _try_pipeline():
+    async def _try_pipeline() -> Optional[List[Tuple[str, str, str]]]:
         uid_dir = REPORT_DIR / str(user_id)
         uid_dir.mkdir(parents=True, exist_ok=True)
 
@@ -186,7 +220,7 @@ async def preview_report(
                 "--pages", "1",
                 "--per_page", str(PREVIEW_PER_PAGE),
                 "--output", str(out),
-                "--formats", "csv",     # только csv для скорости
+                "--formats", "csv",
                 "--keep-csv",
                 "--site", "hh",
             ]
@@ -194,49 +228,102 @@ async def preview_report(
                 cmd += ["--area", str(area)]
 
             log.info("Preview attempt %d: %s", attempt, " ".join(map(str, cmd)))
+            if diagnostic is not None:
+                diagnostic.update(
+                    {
+                        "mode": "pipeline",
+                        "command": [str(part) for part in cmd],
+                        "attempt": attempt,
+                        "error": None,
+                        "stdout": [],
+                        "stderr": [],
+                        "returncode": None,
+                    }
+                )
             try:
                 proc = await asyncio.to_thread(
                     subprocess.run, cmd, capture_output=True, text=True, timeout=PREVIEW_TIMEOUT
                 )
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
                 log.warning("preview timeout (attempt %d)", attempt)
+                if diagnostic is not None:
+                    diagnostic.update(
+                        {
+                            "error": "timeout",
+                            "stdout": (exc.output or "").splitlines(),
+                            "stderr": (exc.stderr or "").splitlines(),
+                            "returncode": None,
+                        }
+                    )
+                continue
+            except Exception as exc:
+                log.warning("preview failed to start pipeline: %s", exc)
+                if diagnostic is not None:
+                    diagnostic.update(
+                        {
+                            "error": str(exc),
+                            "stdout": [],
+                            "stderr": [],
+                            "returncode": None,
+                        }
+                    )
                 continue
 
+            if diagnostic is not None:
+                diagnostic.update(
+                    {
+                        "stdout": (proc.stdout or "").splitlines(),
+                        "stderr": (proc.stderr or "").splitlines(),
+                        "returncode": proc.returncode,
+                    }
+                )
             if proc.returncode != 0:
                 log.warning("preview failed rc=%s: %s", proc.returncode, proc.stderr)
+                if diagnostic is not None:
+                    diagnostic["error"] = f"rc_{proc.returncode}"
                 continue
 
             df = _load_table(out.parent / "raw.csv", None)
             if df is None or df.empty:
+                if diagnostic is not None:
+                    diagnostic["error"] = "empty"
                 return []
 
-            # ранний include/exclude
-            inc = [w.lower() for w in _to_list(include)]
-            exc = [w.lower() for w in _to_list(exclude)]
-            if inc or exc:
+            inc_words = [w.lower() for w in _to_list(include)]
+            exc_words = [w.lower() for w in _to_list(exclude)]
+            if inc_words or exc_words:
                 text_cols = [c for c in df.columns if df[c].dtype == object]
                 blob = (df[text_cols].fillna("").astype(str).agg(" ".join, axis=1).str.lower())
                 mask_inc = True
-                if inc:
+                if inc_words:
                     mask_inc = False
-                    for w in inc:
+                    for w in inc_words:
                         mask_inc = mask_inc | blob.str.contains(w, na=False)
                 mask_exc = False
-                for w in exc:
+                for w in exc_words:
                     mask_exc = mask_exc | blob.str.contains(w, na=False)
                 df = df[mask_inc & (~mask_exc)]
 
-            # собрать строки
-            def _norm(s): return (s or "").strip()
-            col_title   = next((c for c in df.columns if c.lower() in {"name","title","vacancy","position"}), df.columns[0])
-            col_company = next((c for c in df.columns if "company" in c.lower()), df.columns[0])
-            col_url     = next((c for c in df.columns if "url" in c.lower() or "link" in c.lower()), df.columns[0])
+            def _norm(value: object) -> str:
+                if isinstance(value, str):
+                    return value.strip()
+                return str(value or "").strip()
 
-            rows: List[Tuple[str,str,str]] = []
-            for _, r in df.head(PREVIEW_ROWS).iterrows():
-                rows.append((_norm(str(r.get(col_title, ""))),
-                             _norm(str(r.get(col_company, ""))),
-                             _norm(str(r.get(col_url, "")))))
+            col_title = next((c for c in df.columns if c.lower() in {"name", "title", "vacancy", "position"}), df.columns[0])
+            col_company = next((c for c in df.columns if "company" in c.lower()), df.columns[0])
+            col_url = next((c for c in df.columns if "url" in c.lower() or "link" in c.lower()), df.columns[0])
+
+            rows: List[Tuple[str, str, str]] = []
+            for _, row in df.head(PREVIEW_ROWS).iterrows():
+                rows.append(
+                    (
+                        _norm(row.get(col_title, "")),
+                        _norm(row.get(col_company, "")),
+                        _norm(row.get(col_url, "")),
+                    )
+                )
+            if diagnostic is not None:
+                diagnostic["error"] = None
             return rows
 
         return None
@@ -247,14 +334,12 @@ async def preview_report(
     if mode == "pipeline_only":
         return await _try_pipeline()
 
-    # смешанные режимы
     if mode == "api_first":
         rows = _try_api()
         if rows:
             return rows
         return await _try_pipeline()
 
-    # pipeline_first (по умолчанию на случай опечатки)
     rows = await _try_pipeline()
     if rows:
         return rows
@@ -269,8 +354,8 @@ async def preview_rows(
     area: Optional[int] = None,
     include: Iterable[str] | str | None = None,
     exclude: Iterable[str] | str | None = None,
-) -> List[dict[str, str]]:
-    """Возвращает первые строки превью в виде списка словарей."""
+) -> PreviewResult:
+    """Возвращает первые строки превью вместе с диагностикой."""
 
     def _norm(val) -> str:
         if val is None:
@@ -298,63 +383,163 @@ async def preview_rows(
             return base
         return _norm(val)
 
-    rows_raw = await preview_report(
-        user_id,
-        query,
-        city,
-        area=area,
-        include=include,
-        exclude=exclude,
-    )
+    include_list = _to_list(include)
+    exclude_list = _to_list(exclude)
 
-    if not rows_raw:
-        return []
+    diagnostic: Dict[str, Any] = {}
+    user_dir = REPORT_DIR / str(user_id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    bundle_prefix = f"preview_{uuid.uuid4().hex[:6]}"
+    base_meta: Dict[str, Any] = {
+        "mode": "preview",
+        "user_id": user_id,
+        "query": query,
+        "city": city,
+        "area": area,
+        "include": include_list,
+        "exclude": exclude_list,
+    }
+
+    try:
+        rows_raw = await preview_report(
+            user_id,
+            query,
+            city,
+            area=area,
+            include=include,
+            exclude=exclude,
+            diagnostic=diagnostic,
+        )
+    except Exception as exc:
+        stack_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        error_meta = dict(base_meta)
+        error_meta.update(
+            {
+                "status": "error",
+                "error": str(exc),
+                "source_mode": diagnostic.get("mode"),
+                "attempt": diagnostic.get("attempt"),
+                "command": diagnostic.get("command"),
+                "returncode": diagnostic.get("returncode"),
+            }
+        )
+        bundle = write_bundle(
+            user_dir,
+            bundle_prefix,
+            error_meta,
+            diagnostic.get("stdout") or [],
+            diagnostic.get("stderr") or [],
+            stack=stack_text,
+        )
+        log_event(
+            "diagnostic_bundle_ready",
+            level="ERROR",
+            message="Diagnostic bundle prepared",
+            kind="preview",
+            ok=False,
+            err=str(exc),
+            path=str(bundle.path),
+            bundle_id=bundle.bundle_id,
+        )
+        raise DiagnosticError(
+            str(exc) or "preview_failed",
+            bundle_path=bundle.path,
+            bundle_id=bundle.bundle_id,
+        ) from exc
 
     rows_out: List[dict[str, str]] = []
-    for item in rows_raw:
-        if isinstance(item, dict):
-            title = _norm(
-                item.get("title")
-                or item.get("name")
-                or item.get("vacancy")
-                or item.get("position")
+    if rows_raw:
+        for item in rows_raw:
+            if isinstance(item, dict):
+                title = _norm(
+                    item.get("title")
+                    or item.get("name")
+                    or item.get("vacancy")
+                    or item.get("position")
+                )
+                employer = item.get("employer") or {}
+                if not isinstance(employer, dict):
+                    employer = {"name": employer}
+                company = _norm(
+                    item.get("company")
+                    or item.get("employer_name")
+                    or employer.get("name")
+                )
+                salary = _norm_salary(item.get("salary"))
+                link = _norm(item.get("link") or item.get("url") or item.get("alternate_url"))
+            elif isinstance(item, (list, tuple)):
+                parts = list(item) + ["", "", ""]
+                title = _norm(parts[0])
+                company = _norm(parts[1])
+                link = _norm(parts[2])
+                salary = _norm(parts[3])
+            else:
+                title = _norm(item)
+                company = ""
+                link = ""
+                salary = ""
+
+            rows_out.append(
+                {
+                    "title": title,
+                    "company": company,
+                    "salary": salary,
+                    "link": link,
+                }
             )
-            employer = item.get("employer") or {}
-            if not isinstance(employer, dict):
-                employer = {"name": employer}
-            company = _norm(
-                item.get("company")
-                or item.get("employer_name")
-                or employer.get("name")
-            )
-            salary = _norm_salary(item.get("salary"))
-            link = _norm(item.get("link") or item.get("url") or item.get("alternate_url"))
-        elif isinstance(item, (list, tuple)):
-            parts = list(item) + ["", "", ""]
-            title = _norm(parts[0])
-            company = _norm(parts[1])
-            link = _norm(parts[2])
-            salary = _norm(parts[3])
-        else:
-            title = _norm(item)
-            company = ""
-            link = ""
-            salary = ""
 
-        rows_out.append({
-            "title": title,
-            "company": company,
-            "salary": salary,
-            "link": link,
-        })
+    success_meta = dict(base_meta)
+    success_meta.update(
+        {
+            "status": "ok",
+            "rows": len(rows_out),
+            "source_mode": diagnostic.get("mode"),
+            "attempt": diagnostic.get("attempt"),
+            "command": diagnostic.get("command"),
+            "returncode": diagnostic.get("returncode"),
+            "error": diagnostic.get("error"),
+        }
+    )
 
-    return rows_out
+    bundle = write_bundle(
+        user_dir,
+        bundle_prefix,
+        success_meta,
+        diagnostic.get("stdout") or [],
+        diagnostic.get("stderr") or [],
+    )
+    log_event(
+        "diagnostic_bundle_ready",
+        message="Diagnostic bundle prepared",
+        kind="preview",
+        ok=True,
+        path=str(bundle.path),
+        bundle_id=bundle.bundle_id,
+        rows=len(rows_out),
+    )
 
+    return PreviewResult(rows=rows_out, bundle_path=bundle.path, bundle_id=bundle.bundle_id)
 
 @dataclass
 class ReportResult:
     xlsx_path: Path
     csv_path: Path | None = None
+    bundle_path: Path | None = None
+    bundle_id: str | None = None
+
+
+@dataclass
+class PreviewResult:
+    rows: List[dict[str, str]]
+    bundle_path: Path | None = None
+    bundle_id: str | None = None
+
+
+class DiagnosticError(RuntimeError):
+    def __init__(self, message: str, *, bundle_path: Path, bundle_id: str):
+        super().__init__(message)
+        self.bundle_path = bundle_path
+        self.bundle_id = bundle_id
 
 
 ProgressCallback = Callable[[str, dict], Awaitable[None]]
@@ -392,7 +577,7 @@ async def run_report(
         "--query", query,
         "--city", city,
         "--output", str(out_path),
-        "--formats", "xlsx", "csv",   # отдельно значениями
+        "--formats", "xlsx", "csv",
         "--keep-csv",
     ]
     if role:
@@ -415,81 +600,153 @@ async def run_report(
     stderr_lines: list[str] = []
     csv_path: Path | None = None
 
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-
-    async def _read_stdout() -> None:
-        nonlocal csv_path
-        assert proc.stdout is not None
-        while True:
-            line = await proc.stdout.readline()
-            if not line:
-                break
-            text_line = line.decode(errors="ignore").rstrip("\r\n")
-            stdout_lines.append(text_line)
-            if progress:
-                try:
-                    payload = json.loads(text_line)
-                except json.JSONDecodeError:
-                    continue
-                if payload.get("status") == "csv" and payload.get("path"):
-                    try:
-                        csv_path = Path(payload["path"])
-                    except Exception:  # pragma: no cover
-                        csv_path = None
-                try:
-                    await progress("status", payload)
-                except Exception:  # pragma: no cover
-                    log.warning("progress callback failed", exc_info=True)
-
-    async def _read_stderr() -> None:
-        assert proc.stderr is not None
-        while True:
-            line = await proc.stderr.readline()
-            if not line:
-                break
-            stderr_lines.append(line.decode(errors="ignore").rstrip("\r\n"))
-
-    stdout_task = asyncio.create_task(_read_stdout())
-    stderr_task = asyncio.create_task(_read_stderr())
+    bundle_meta: Dict[str, object] = {
+        "mode": "report",
+        "user_id": user_id,
+        "query": query,
+        "city": city,
+        "role": role,
+        "pages": pages,
+        "per_page": per_page,
+        "pause": pause,
+        "site": site,
+        "area": area,
+        "include": inc,
+        "exclude": exc,
+        "timeout": eff_timeout,
+        "command": [str(part) for part in cmd],
+        "report_path": str(out_path),
+    }
+    bundle_prefix = f"report_{uuid.uuid4().hex[:6]}"
 
     try:
-        await asyncio.wait_for(proc.wait(), timeout=eff_timeout)
-    except asyncio.TimeoutError as e:
-        proc.kill()
-        await proc.wait()
-        log.error("Parser timeout")
-        raise RuntimeError("Превышено время ожидания парсера") from e
-    finally:
-        await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
-
-    if proc.returncode != 0:
-        stdout_text = "\n".join(stdout_lines)
-        stderr_text = "\n".join(stderr_lines)
-        log.error(
-            "Parser failed (rc=%s)\nstdout:\n%s\nstderr:\n%s",
-            proc.returncode,
-            stdout_text,
-            stderr_text,
-        )
-        raise RuntimeError(
-            f"Не удалось получить отчёт: парсер завершился с ошибкой {proc.returncode}"
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
 
-    if inc or exc:
-        if progress:
-            try:
-                await progress("filter_start", {"csv_path": str(csv_path) if csv_path else None})
-            except Exception:  # pragma: no cover
-                log.warning("progress callback failed on filter_start", exc_info=True)
-        await asyncio.to_thread(_postfilter_any, out_path, inc, exc, csv_path=csv_path)
-        if progress:
-            try:
-                await progress("filter_done", {"csv_path": str(csv_path) if csv_path else None})
-            except Exception:  # pragma: no cover
-                log.warning("progress callback failed on filter_done", exc_info=True)
+        async def _read_stdout() -> None:
+            nonlocal csv_path
+            assert proc.stdout is not None
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                text_line = line.decode(errors="ignore").rstrip("\r\n")
+                stdout_lines.append(text_line)
+                if progress:
+                    try:
+                        payload = json.loads(text_line)
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("status") == "csv" and payload.get("path"):
+                        try:
+                            csv_path = Path(payload["path"])
+                        except Exception:  # pragma: no cover
+                            csv_path = None
+                    try:
+                        await progress("status", payload)
+                    except Exception:  # pragma: no cover
+                        log.warning("progress callback failed", exc_info=True)
 
-    return ReportResult(xlsx_path=out_path, csv_path=csv_path)
+        async def _read_stderr() -> None:
+            assert proc.stderr is not None
+            while True:
+                line = await proc.stderr.readline()
+                if not line:
+                    break
+                stderr_lines.append(line.decode(errors="ignore").rstrip("\r\n"))
+
+        stdout_task = asyncio.create_task(_read_stdout())
+        stderr_task = asyncio.create_task(_read_stderr())
+
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=eff_timeout)
+        except asyncio.TimeoutError as e:
+            proc.kill()
+            await proc.wait()
+            log.error("Parser timeout")
+            raise RuntimeError("Превышено время ожидания парсера") from e
+        finally:
+            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+
+        if proc.returncode != 0:
+            stdout_text = "\n".join(stdout_lines)
+            stderr_text = "\n".join(stderr_lines)
+            log.error(
+                "Parser failed (rc=%s)\nstdout:\n%s\nstderr:\n%s",
+                proc.returncode,
+                stdout_text,
+                stderr_text,
+            )
+            raise RuntimeError(
+                f"Не удалось получить отчёт: парсер завершился с ошибкой {proc.returncode}"
+            )
+
+        if inc or exc:
+            if progress:
+                try:
+                    await progress("filter_start", {"csv_path": str(csv_path) if csv_path else None})
+                except Exception:  # pragma: no cover
+                    log.warning("progress callback failed on filter_start", exc_info=True)
+            await asyncio.to_thread(_postfilter_any, out_path, inc, exc, csv_path=csv_path)
+            if progress:
+                try:
+                    await progress("filter_done", {"csv_path": str(csv_path) if csv_path else None})
+                except Exception:  # pragma: no cover
+                    log.warning("progress callback failed on filter_done", exc_info=True)
+
+        bundle_meta["csv_path"] = str(csv_path) if csv_path else None
+    except Exception as exc:
+        stack_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        error_meta = dict(bundle_meta)
+        error_meta["status"] = "error"
+        error_meta["error"] = str(exc)
+        bundle = write_bundle(
+            user_dir,
+            bundle_prefix,
+            error_meta,
+            stdout_lines,
+            stderr_lines,
+            stack=stack_text,
+        )
+        log_event(
+            "diagnostic_bundle_ready",
+            level="ERROR",
+            message="Diagnostic bundle prepared",
+            kind="report",
+            ok=False,
+            err=str(exc),
+            path=str(bundle.path),
+            bundle_id=bundle.bundle_id,
+        )
+        raise DiagnosticError(
+            str(exc) or "report_failed",
+            bundle_path=bundle.path,
+            bundle_id=bundle.bundle_id,
+        ) from exc
+
+    success_meta = dict(bundle_meta)
+    success_meta["status"] = "ok"
+    bundle = write_bundle(
+        user_dir,
+        bundle_prefix,
+        success_meta,
+        stdout_lines,
+        stderr_lines,
+    )
+    log_event(
+        "diagnostic_bundle_ready",
+        message="Diagnostic bundle prepared",
+        kind="report",
+        ok=True,
+        path=str(bundle.path),
+        bundle_id=bundle.bundle_id,
+    )
+    return ReportResult(
+        xlsx_path=out_path,
+        csv_path=csv_path,
+        bundle_path=bundle.path,
+        bundle_id=bundle.bundle_id,
+    )

--- a/app/utils/callbacks.py
+++ b/app/utils/callbacks.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from aiogram import types
+from aiogram.utils.exceptions import InvalidQueryID, QueryIdInvalid
+
+from app.utils.logging import log_event
+
+
+async def safe_answer(
+    callback: types.CallbackQuery,
+    text: str | None = None,
+    *,
+    show_alert: bool | None = None,
+    cache_time: int | None = None,
+    url: str | None = None,
+    **kwargs: Any,
+) -> bool:
+    """Safely acknowledge callback queries and handle expired ones."""
+
+    answer_kwargs: dict[str, Any] = {}
+    if show_alert is not None:
+        answer_kwargs["show_alert"] = show_alert
+    if cache_time is not None:
+        answer_kwargs["cache_time"] = cache_time
+    if url is not None:
+        answer_kwargs["url"] = url
+    answer_kwargs.update(kwargs)
+
+    try:
+        await callback.answer(text, **answer_kwargs)
+        return True
+    except (InvalidQueryID, QueryIdInvalid) as exc:
+        message = callback.message
+        chat_id = message.chat.id if message else None
+        data_preview = (callback.data or "")[:256]
+        age_seconds: float | None = None
+        if message and message.date:
+            msg_dt = message.date
+            if msg_dt.tzinfo is None:
+                age_seconds = (datetime.utcnow() - msg_dt).total_seconds()
+            else:
+                age_seconds = (
+                    datetime.now(timezone.utc) - msg_dt.astimezone(timezone.utc)
+                ).total_seconds()
+        log_event(
+            "callback_expired",
+            level="WARN",
+            message="Callback query expired",
+            callback_data=data_preview,
+            age_seconds=age_seconds,
+            chat_id=chat_id,
+            err=str(exc),
+        )
+        try:
+            if message:
+                reply_markup = message.reply_markup
+                await message.answer(
+                    "Кнопка устарела, пожалуйста, повторите действие.",
+                    reply_markup=reply_markup,
+                )
+        except Exception:  # pragma: no cover - we do not want to fail handlers here
+            pass
+        return False

--- a/app/utils/diagnostics.py
+++ b/app/utils/diagnostics.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+ENV_WHITELIST: Sequence[str] = (
+    "MODE",
+    "PORT",
+    "WEBAPP_PORT",
+    "WEBHOOK_URL",
+    "REPLIT_RELEASE",
+    "PYTHON_VERSION",
+    "PARSER_PIPELINE",
+    "PARSER_TIMEOUT",
+    "PARSER_TIMEOUT_LARGE",
+    "PREVIEW_MODE",
+    "PREVIEW_TIMEOUT",
+    "PREVIEW_RETRIES",
+    "PREVIEW_ROWS",
+    "REPORT_DIR",
+)
+
+
+def _gather_env() -> str:
+    rows: list[str] = []
+    for key in ENV_WHITELIST:
+        value = os.getenv(key)
+        if value is not None:
+            rows.append(f"{key}={value}")
+    return "\n".join(rows)
+
+
+@dataclass
+class DiagnosticBundle:
+    path: Path
+    bundle_id: str
+
+    @property
+    def stack_path(self) -> Path:
+        return self.path / "stack.txt"
+
+
+def write_bundle(
+    base_dir: Path,
+    prefix: str,
+    meta: dict,
+    stdout_lines: Iterable[str],
+    stderr_lines: Iterable[str],
+    *,
+    stack: str | None = None,
+) -> DiagnosticBundle:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    bundle_dir = base_dir / f"{prefix}_{ts}"
+    counter = 1
+    while bundle_dir.exists():
+        counter += 1
+        bundle_dir = base_dir / f"{prefix}_{ts}_{counter}"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    bundle_id = bundle_dir.name
+    meta = dict(meta)
+    meta.setdefault("created_at", datetime.now(timezone.utc).isoformat())
+    meta.setdefault("bundle_id", bundle_id)
+
+    (bundle_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (bundle_dir / "stdout.txt").write_text("\n".join(stdout_lines), encoding="utf-8")
+    (bundle_dir / "stderr.txt").write_text("\n".join(stderr_lines), encoding="utf-8")
+    (bundle_dir / "env.txt").write_text(_gather_env(), encoding="utf-8")
+    if stack:
+        (bundle_dir / "stack.txt").write_text(stack, encoding="utf-8")
+
+    return DiagnosticBundle(path=bundle_dir, bundle_id=bundle_id)

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -1,7 +1,13 @@
+
+from datetime import datetime, timezone
+
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
 from aiogram import Bot, Dispatcher, types
 
 from .config import settings
+from .utils.logging import log_event
+
 
 app = FastAPI()
 _dp: Dispatcher | None = None
@@ -15,8 +21,30 @@ def set_dispatcher(dp: Dispatcher):
 
 
 @app.get("/")
-async def health_check():
-    return {"status": "ok"}
+async def root() -> PlainTextResponse:
+    return PlainTextResponse("HR-Assist webhook is running.")
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok", "version": settings.BUILD_VERSION})
+
+
+@app.get("/_debug")
+async def debug_info() -> JSONResponse:
+    data = {
+        "status": "ok",
+        "mode": settings.MODE,
+        "webhook_url": settings.WEBHOOK_URL,
+        "webapp_port": settings.WEBAPP_PORT,
+        "webapp_port_source": settings.WEBAPP_PORT_SOURCE,
+        "build_version": settings.BUILD_VERSION,
+        "dispatcher_ready": _dp is not None,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "health_url": f"http://0.0.0.0:{settings.WEBAPP_PORT}/health",
+    }
+    return JSONResponse(data)
+
 
 @app.post("/webhook")
 async def handle_update(request: Request):
@@ -24,31 +52,47 @@ async def handle_update(request: Request):
         return {"status": "dispatcher not ready"}
     data = await request.json()
     update = types.Update(**data)
+    if _bot:
+        Bot.set_current(_bot)
     await _dp.process_update(update)
     return {"status": "ok"}
 
 
 async def setup_webhook(bot: Bot):
-    """Setup webhook with validation and error handling for deployment"""
+    """Setup webhook with validation and logging."""
     if not settings.WEBHOOK_URL:
         raise ValueError("WEBHOOK_URL is required for webhook mode")
-    
-    # Validate webhook URL format
-    if not settings.WEBHOOK_URL.startswith(('https://', 'http://localhost')):
+
+    if not settings.WEBHOOK_URL.startswith(("https://", "http://localhost")):
         raise ValueError("WEBHOOK_URL must use HTTPS (or HTTP for localhost)")
-    
+
     if '/webhook' not in settings.WEBHOOK_URL:
         raise ValueError("WEBHOOK_URL should end with '/webhook' endpoint")
-    
-    try:
-        await bot.set_webhook(settings.WEBHOOK_URL)
-        print(f"Webhook successfully set to: {settings.WEBHOOK_URL}")
-    except Exception as e:
-        print(f"Failed to set webhook: {e}")
-        print("This might be expected during development or if the deployment URL is not yet accessible")
-        # Re-raise for proper error handling
-        raise
+
+    info = await bot.get_webhook_info()
+    log_event(
+        "webhook_info",
+        message="Webhook info fetched",
+        url=info.url,
+        pending_updates=info.pending_update_count,
+        last_error_message=info.last_error_message,
+        has_custom_certificate=info.has_custom_certificate,
+        ip_address=info.ip_address,
+    )
+
+    desired_url = settings.WEBHOOK_URL
+    if info.url == desired_url:
+        log_event("webhook_setup", message="Webhook already configured", url=desired_url)
+        return
+
+    if info.url:
+        await bot.delete_webhook(drop_pending_updates=True)
+        log_event("webhook_deleted", message="Previous webhook removed", previous_url=info.url)
+
+    await bot.set_webhook(desired_url)
+    log_event("webhook_setup", message="Webhook configured successfully", url=desired_url)
 
 
 async def remove_webhook(bot: Bot):
     await bot.delete_webhook()
+    log_event("webhook_removed", message="Webhook removed")

--- a/tests/test_preview_rows.py
+++ b/tests/test_preview_rows.py
@@ -10,15 +10,17 @@ from app.services import parser_adapter
 
 
 def test_preview_rows_converts_to_dict(monkeypatch):
-    async def fake_preview_report(*args, **kwargs):
+    async def fake_preview_report(*args, diagnostic=None, **kwargs):
+        if diagnostic is not None:
+            diagnostic.update({"mode": "api", "stdout": [], "stderr": [], "returncode": 0, "attempt": None, "error": None})
         return [("Dev", "Acme", "https://hh.ru/vacancy/1")]
 
     monkeypatch.setattr(parser_adapter, "preview_report", fake_preview_report)
 
-    rows = asyncio.run(parser_adapter.preview_rows(123, "Dev", "Москва"))
+    result = asyncio.run(parser_adapter.preview_rows(123, "Dev", "Москва"))
 
-    assert isinstance(rows, list)
-    assert rows == [
+    assert isinstance(result.rows, list)
+    assert result.rows == [
         {
             "title": "Dev",
             "company": "Acme",
@@ -26,14 +28,19 @@ def test_preview_rows_converts_to_dict(monkeypatch):
             "link": "https://hh.ru/vacancy/1",
         }
     ]
+    assert result.bundle_path.is_dir()
+    assert result.bundle_id
 
 
 def test_preview_rows_handles_empty(monkeypatch):
-    async def fake_preview_report(*args, **kwargs):
+    async def fake_preview_report(*args, diagnostic=None, **kwargs):
+        if diagnostic is not None:
+            diagnostic.update({"mode": "api", "stdout": [], "stderr": [], "returncode": 0, "attempt": None, "error": None})
         return None
 
     monkeypatch.setattr(parser_adapter, "preview_report", fake_preview_report)
 
-    rows = asyncio.run(parser_adapter.preview_rows(1, "", ""))
+    result = asyncio.run(parser_adapter.preview_rows(1, "", ""))
 
-    assert rows == []
+    assert result.rows == []
+    assert result.bundle_path.is_dir()


### PR DESCRIPTION
## Summary
- add deterministic port selection and startup banner logging for webhook deployments
- expose health, root, and debug endpoints while hardening webhook setup and logging
- implement diagnostic bundles, safe callback acknowledgements, and update tests for the new preview API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d654597fa88320a1c8db336eab7b8f