### PR TITLE
Add compat layer for aiogram callback errors

### DIFF
--- a/app/compat/__init__.py
+++ b/app/compat/__init__.py
@@ -1,0 +1,18 @@
+"""Compatibility helpers for dealing with aiogram differences."""
+
+from .aiogram_exceptions import (
+    BadRequest,
+    InvalidQueryID,
+    QueryIdInvalid,
+    callback_invalid_exc,
+    callback_invalid_exc_names,
+)
+
+__all__ = [
+    "BadRequest",
+    "InvalidQueryID",
+    "QueryIdInvalid",
+    "callback_invalid_exc",
+    "callback_invalid_exc_names",
+]
+

--- a/app/compat/aiogram_exceptions.py
+++ b/app/compat/aiogram_exceptions.py
@@ -1,0 +1,58 @@
+"""Compatibility layer for aiogram exceptions.
+
+The aiogram 2.x series renamed several exceptions between minor releases.
+This module resolves the available names at import time and exposes a
+consistent API to the rest of the project.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple, Type
+
+from aiogram.utils import exceptions as aio_exceptions
+
+InvalidQueryID: Type[BaseException] | None = getattr(
+    aio_exceptions, "InvalidQueryID", None
+)
+QueryIdInvalid: Type[BaseException] | None = getattr(
+    aio_exceptions, "QueryIdInvalid", None
+)
+
+if InvalidQueryID is None and QueryIdInvalid is None:  # pragma: no cover - defensive
+    raise ImportError("aiogram.utils.exceptions does not expose callback query errors")
+
+if InvalidQueryID is None:
+    InvalidQueryID = QueryIdInvalid  # type: ignore[assignment]
+elif QueryIdInvalid is None:
+    QueryIdInvalid = InvalidQueryID
+
+# Ensure names are available at module level for static analyzers and runtime.
+globals()["InvalidQueryID"] = InvalidQueryID
+globals()["QueryIdInvalid"] = QueryIdInvalid
+
+BadRequest: Type[BaseException] = aio_exceptions.BadRequest
+
+callback_invalid_exc: Tuple[Type[BaseException], ...] = (
+    InvalidQueryID,
+    QueryIdInvalid,
+    BadRequest,
+)
+
+callback_invalid_exc_names: Tuple[str, ...] = tuple(
+    name
+    for name, value in (
+        ("InvalidQueryID", InvalidQueryID),
+        ("QueryIdInvalid", QueryIdInvalid),
+        ("BadRequest", BadRequest),
+    )
+    if value is not None
+)
+
+__all__ = [
+    "BadRequest",
+    "InvalidQueryID",
+    "QueryIdInvalid",
+    "callback_invalid_exc",
+    "callback_invalid_exc_names",
+]
+

--- a/app/run.py
+++ b/app/run.py
@@ -13,6 +13,7 @@ from aiogram.contrib.fsm_storage.memory import MemoryStorage
 from aiogram.utils.exceptions import TelegramAPIError
 
 from . import webhook
+from .compat import callback_invalid_exc_names
 from .config import settings
 from .handlers import (
     admin as h_admin,
@@ -121,6 +122,9 @@ def main() -> None:
             f"Starting bot in {settings.MODE} mode "
             f"(aiogram={aiogram.__version__}, aiohttp={aiohttp.__version__})"
         ),
+        aiogram_version=aiogram.__version__,
+        aiohttp_version=aiohttp.__version__,
+        callback_invalid_exceptions=list(callback_invalid_exc_names),
     )
 
     logger.info("startup_ok", extra={"event": "startup"})

--- a/app/utils/callbacks.py
+++ b/app/utils/callbacks.py
@@ -1,66 +1,147 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Dict
 
 from aiogram import types
-from aiogram.utils.exceptions import InvalidQueryID, QueryIdInvalid
 
+from app.compat import BadRequest, InvalidQueryID, QueryIdInvalid, callback_invalid_exc
 from app.utils.logging import log_event
+
+STALE_MARKERS = ("query is too old", "query_id_invalid")
+
+
+@dataclass
+class SafeAnswerResult:
+    ok: bool
+    detail: str
+
+    def __bool__(self) -> bool:  # pragma: no cover - simple delegation
+        return self.ok
+
+    def as_tuple(self) -> tuple[bool, str]:
+        return self.ok, self.detail
+
+    def __iter__(self):  # pragma: no cover - convenience for unpacking
+        yield from (self.ok, self.detail)
+
+
+def _callback_log_context(callback: types.CallbackQuery) -> Dict[str, Any]:
+    message = callback.message
+    user = callback.from_user
+    context: Dict[str, Any] = {
+        "callback_id": getattr(callback, "id", None),
+        "callback_data": (callback.data or "")[:256],
+        "chat_id": message.chat.id if message and message.chat else None,
+        "user_id": user.id if user else None,
+    }
+    if user:
+        if user.username:
+            context.setdefault("username", user.username)
+        if user.full_name:
+            context.setdefault("full_name", user.full_name)
+    if message:
+        context.setdefault("message_id", message.message_id)
+    return context
+
+
+def _calculate_age_seconds(callback: types.CallbackQuery) -> float | None:
+    message = callback.message
+    if not message:
+        return None
+    timestamp = getattr(message, "edit_date", None) or getattr(message, "date", None)
+    if not timestamp:
+        return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return (now - timestamp.astimezone(timezone.utc)).total_seconds()
+
+
+def _is_stale_exception(exc: BaseException) -> bool:
+    if isinstance(exc, (InvalidQueryID, QueryIdInvalid)):
+        return True
+    if isinstance(exc, BadRequest):
+        message = str(exc).lower()
+        return any(marker in message for marker in STALE_MARKERS)
+    message = str(exc).lower()
+    return any(marker in message for marker in STALE_MARKERS)
 
 
 async def safe_answer(
     callback: types.CallbackQuery,
     text: str | None = None,
+    show_alert: bool = False,
+    cache_time: int = 0,
     *,
-    show_alert: bool | None = None,
-    cache_time: int | None = None,
-    url: str | None = None,
+    expired_text: str | None = "Кнопка устарела. Пожалуйста, повторите действие.",
+    notify_user_on_expired: bool = True,
+    log_extra: Dict[str, Any] | None = None,
     **kwargs: Any,
-) -> bool:
+) -> SafeAnswerResult:
     """Safely acknowledge callback queries and handle expired ones."""
 
-    answer_kwargs: dict[str, Any] = {}
-    if show_alert is not None:
-        answer_kwargs["show_alert"] = show_alert
-    if cache_time is not None:
-        answer_kwargs["cache_time"] = cache_time
-    if url is not None:
-        answer_kwargs["url"] = url
-    answer_kwargs.update(kwargs)
+    answer_kwargs: dict[str, Any] = dict(kwargs)
+    answer_kwargs.setdefault("show_alert", show_alert)
+    answer_kwargs.setdefault("cache_time", cache_time)
+
+    log_context = _callback_log_context(callback)
+    if log_extra:
+        log_context.update(log_extra)
 
     try:
         await callback.answer(text, **answer_kwargs)
-        return True
-    except (InvalidQueryID, QueryIdInvalid) as exc:
-        message = callback.message
-        chat_id = message.chat.id if message else None
-        data_preview = (callback.data or "")[:256]
-        age_seconds: float | None = None
-        if message and message.date:
-            msg_dt = message.date
-            if msg_dt.tzinfo is None:
-                age_seconds = (datetime.utcnow() - msg_dt).total_seconds()
-            else:
-                age_seconds = (
-                    datetime.now(timezone.utc) - msg_dt.astimezone(timezone.utc)
-                ).total_seconds()
-        log_event(
-            "callback_expired",
-            level="WARN",
-            message="Callback query expired",
-            callback_data=data_preview,
-            age_seconds=age_seconds,
-            chat_id=chat_id,
-            err=str(exc),
+    except callback_invalid_exc as exc:
+        expired = _is_stale_exception(exc)
+        age_seconds = _calculate_age_seconds(callback)
+        detail = "expired" if expired else f"error:{type(exc).__name__}"
+        level = "WARN" if expired else "ERROR"
+        log_payload = {
+            **log_context,
+            "age_seconds": age_seconds,
+            "err": str(exc),
+            "exception_type": type(exc).__name__,
+        }
+        event = "callback_expired" if expired else "callback_error"
+        message_text = (
+            "Callback query expired"
+            if expired
+            else "Failed to answer callback query"
         )
-        try:
-            if message:
-                reply_markup = message.reply_markup
-                await message.answer(
-                    "Кнопка устарела, пожалуйста, повторите действие.",
-                    reply_markup=reply_markup,
+        log_event(event, level=level, message=message_text, **log_payload)
+
+        if expired and notify_user_on_expired and expired_text and callback.message:
+            try:
+                await callback.message.answer(
+                    expired_text,
+                    reply_markup=callback.message.reply_markup,
                 )
-        except Exception:  # pragma: no cover - we do not want to fail handlers here
-            pass
-        return False
+            except Exception as notify_exc:  # pragma: no cover - defensive logging
+                log_event(
+                    "callback_expired_notify_failed",
+                    level="WARN",
+                    message="Failed to notify user about expired callback",
+                    err=str(notify_exc),
+                    exception_type=type(notify_exc).__name__,
+                    **log_context,
+                )
+        return SafeAnswerResult(False, detail)
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        log_event(
+            "callback_error",
+            level="ERROR",
+            message="Failed to answer callback query",
+            err=str(exc),
+            exception_type=type(exc).__name__,
+            **log_context,
+        )
+        return SafeAnswerResult(False, f"error:{type(exc).__name__}")
+
+    log_event(
+        "callback_ack",
+        level="DEBUG",
+        message="Callback acknowledged",
+        **log_context,
+    )
+    return SafeAnswerResult(True, "ack")


### PR DESCRIPTION
## Summary
- add a compatibility layer that aliases aiogram callback query exception names and exposes a shared tuple for stale detection
- harden `safe_answer` to acknowledge callbacks safely, classify expired queries, emit structured logs, and optionally notify users
- log the resolved aiogram exception names during startup for better diagnostics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d65c9641388320aa5c98d84d37b1d8