### PR TITLE
Fix dispatcher context and add diagnostics

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -47,6 +47,7 @@ def create_dispatcher() -> Dispatcher:
     bot = LoggedBot(token=settings.TELEGRAM_BOT_TOKEN, parse_mode="HTML")
     Bot.set_current(bot)
     dp = Dispatcher(bot, storage=MemoryStorage())
+    Dispatcher.set_current(dp)
 
     # ---- global errors handler (aiogram v2) ----
     @dp.errors_handler()

--- a/app/utils/diagnostics.py
+++ b/app/utils/diagnostics.py
@@ -1,11 +1,27 @@
+"""Diagnostic helpers for persistent bundles and runtime snapshots."""
+
 from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Any, Dict, Iterable, Sequence
+
+try:  # pragma: no cover - optional dependency during tests
+    from aiogram import Dispatcher  # type: ignore
+    from aiogram.contrib.fsm_storage.memory import MemoryStorage  # type: ignore
+    from aiogram.dispatcher.storage import BaseStorage  # type: ignore
+except Exception:  # pragma: no cover - aiogram may be absent in tests
+    Dispatcher = None  # type: ignore
+    MemoryStorage = None  # type: ignore
+    BaseStorage = None  # type: ignore
+
+try:  # pragma: no cover - optional busy middleware during tests
+    from app.middlewares.busy import BUSY_USERS  # type: ignore
+except Exception:  # pragma: no cover - dependency chain may be missing
+    BUSY_USERS = set()
 
 ENV_WHITELIST: Sequence[str] = (
     "MODE",
@@ -78,3 +94,76 @@ def write_bundle(
         (bundle_dir / "stack.txt").write_text(stack, encoding="utf-8")
 
     return DiagnosticBundle(path=bundle_dir, bundle_id=bundle_id)
+
+
+@dataclass
+class StorageDiagnostics:
+    """Safe snapshot of FSM storage internals."""
+
+    type: str
+    user_count: int | None = None
+    state_keys: int | None = None
+    data_preview: Dict[str, Any] | None = None
+    error: str | None = None
+
+
+def _describe_memory_storage(storage: MemoryStorage) -> StorageDiagnostics:  # type: ignore[arg-type]
+    """Return diagnostic info for :class:`MemoryStorage`."""
+
+    try:
+        raw_storage: Dict[Any, Dict[Any, Dict[str, Any]]] = getattr(storage, "storage", {})
+        user_count = 0
+        state_keys = 0
+        preview: Dict[str, Any] = {}
+        for chat_id, users in list(raw_storage.items()):
+            if not isinstance(users, dict):
+                continue
+            for user_id, state_data in users.items():
+                user_count += 1
+                if isinstance(state_data, dict):
+                    state_keys += len(state_data)
+                    if len(preview) < 5:
+                        key = f"{chat_id}:{user_id}"
+                        preview[key] = {k: v for k, v in state_data.items() if k != "data"}
+        return StorageDiagnostics(
+            type=type(storage).__name__,
+            user_count=user_count,
+            state_keys=state_keys,
+            data_preview=preview or None,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        return StorageDiagnostics(type=type(storage).__name__, error=str(exc))
+
+
+def describe_storage(storage: BaseStorage | None) -> StorageDiagnostics:  # type: ignore[type-arg]
+    """Gather safe diagnostic information about the FSM storage."""
+
+    if storage is None or BaseStorage is None:
+        return StorageDiagnostics(type="<none>")
+    if MemoryStorage is not None and isinstance(storage, MemoryStorage):
+        return _describe_memory_storage(storage)
+    return StorageDiagnostics(type=type(storage).__name__)
+
+
+def collect_runtime_diagnostics(dp: Dispatcher | None) -> Dict[str, Any]:  # type: ignore[type-arg]
+    """Produce a snapshot with useful runtime diagnostics for the webhook UI."""
+
+    diag: Dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "dispatcher_ready": dp is not None,
+        "busy_users": len(BUSY_USERS),
+    }
+
+    if dp is None or Dispatcher is None:
+        diag["storage"] = asdict(StorageDiagnostics(type="<none>"))
+        return diag
+
+    storage_diag = describe_storage(dp.storage)
+    diag["storage"] = asdict(storage_diag)
+    diag["middlewares"] = [type(m).__name__ for m in getattr(dp.middlewares, "middlewares", [])]
+    diag["registered_handlers"] = {
+        "message": len(dp.message_handlers.handlers),
+        "callback": len(dp.callback_query_handlers.handlers),
+        "errors": len(dp.errors_handlers),
+    }
+    return diag

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -1,11 +1,12 @@
 
-from datetime import datetime, timezone
+from typing import Any, Dict
 
+from aiogram import Bot, Dispatcher, types
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
-from aiogram import Bot, Dispatcher, types
 
 from .config import settings
+from .utils.diagnostics import collect_runtime_diagnostics
 from .utils.logging import log_event
 
 
@@ -18,6 +19,8 @@ def set_dispatcher(dp: Dispatcher):
     global _dp, _bot
     _dp = dp
     _bot = dp.bot
+    Dispatcher.set_current(dp)
+    Bot.set_current(dp.bot)
 
 
 @app.get("/")
@@ -32,17 +35,16 @@ async def health() -> JSONResponse:
 
 @app.get("/_debug")
 async def debug_info() -> JSONResponse:
-    data = {
+    data: Dict[str, Any] = {
         "status": "ok",
         "mode": settings.MODE,
         "webhook_url": settings.WEBHOOK_URL,
         "webapp_port": settings.WEBAPP_PORT,
         "webapp_port_source": settings.WEBAPP_PORT_SOURCE,
         "build_version": settings.BUILD_VERSION,
-        "dispatcher_ready": _dp is not None,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
         "health_url": f"http://0.0.0.0:{settings.WEBAPP_PORT}/health",
     }
+    data.update(collect_runtime_diagnostics(_dp))
     return JSONResponse(data)
 
 
@@ -54,7 +56,20 @@ async def handle_update(request: Request):
     update = types.Update(**data)
     if _bot:
         Bot.set_current(_bot)
-    await _dp.process_update(update)
+    previous_dp = Dispatcher.get_current()
+    if previous_dp is None:
+        log_event(
+            "dispatcher_context_reset",
+            level="DEBUG",
+            message="Dispatcher context was empty before processing update",
+        )
+    Dispatcher.set_current(_dp)
+    try:
+        await _dp.process_update(update)
+    finally:
+        Dispatcher.set_current(None)
+        if _bot:
+            Bot.set_current(None)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- ensure the aiogram dispatcher is registered as current both at startup and for every webhook update to prevent missing FSM context
- extend diagnostics utilities to include runtime FSM/storage snapshots while keeping bundle generation, and surface the data via the FastAPI debug endpoint
- add defensive fallbacks so diagnostics work even when aiogram is unavailable during tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d66cf59f688320bda7073d5d5fc4f7