### PR TITLE
Fix webhook dispatcher context guard checks

### DIFF
--- a/app/webhook.py
+++ b/app/webhook.py
@@ -65,7 +65,7 @@ async def handle_update(request: Request):
     except LookupError:
         previous_dp = None
 
-    if _bot:
+    if _bot is not None:
         Bot.set_current(_bot)
 
     if previous_dp is None:
@@ -79,9 +79,9 @@ async def handle_update(request: Request):
     try:
         await _dp.process_update(update)
     finally:
-        if previous_dp:
+        if previous_dp is not None:
             Dispatcher.set_current(previous_dp)
-        if previous_bot:
+        if previous_bot is not None:
             Bot.set_current(previous_bot)
     return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- ensure the webhook handler only restores dispatcher and bot contexts when previous instances exist
- guard bot context activation with explicit None checks to prevent invalid Dispatcher.set_current calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6728b96b88320913db4e19b5e9fed