### PR TITLE
Implement stage-based progress reporting for report generation

### DIFF
--- a/app/handlers/parse.py
+++ b/app/handlers/parse.py
@@ -45,7 +45,7 @@ from app import keyboards
 from app.utils.admins import is_admin
 from app.utils.callbacks import safe_answer
 from app.utils.logging import complete_operation, log_event, update_context
-from app.utils.progress import ProgressMessage
+from app.utils.progress import ProgressReporter, create_preview_progress, create_report_progress
 from app.utils.normalize import normalize_city, normalize_role
 
 log = logging.getLogger(__name__)
@@ -55,77 +55,33 @@ _WARN_CACHE: Dict[int, Tuple[str, str, dict]] = {}
 # Кеш шага выбора объёма: user_id -> (norm_title, city, area_id, overrides, max_total)
 _PENDING_QTY: Dict[int, Tuple[str, str, int, dict, int]] = {}
 
-PROGRESS_STEPS_2 = (
-    "Шаг 1/2: собираю вакансии… {spinner}",
-    "Шаг 2/2: формирую Excel-отчёт… {spinner}",
-)
-PROGRESS_STEPS_3 = (
-    "Шаг 1/3: собираю вакансии… {spinner}",
-    "Шаг 2/3: фильтрую по ключевым словам… {spinner}",
-    "Шаг 3/3: формирую Excel-отчёт… {spinner}",
-)
-PREVIEW_TEMPLATE = "Готовлю превью (5 вакансий)… {spinner}"
 DONE_TEXT = "Готово ✅"
 FAIL_TEXT = "❌ Не получилось (ошибка/таймаут). Попробуй позже."
-
-
-class ReportProgressTracker:
-    def __init__(self, progress: ProgressMessage, steps: tuple[str, ...]):
-        self._progress = progress
-        self._steps = steps
-        self._current = 0
-        self._finished = False
-
-    @property
-    def has_filter(self) -> bool:
-        return len(self._steps) == len(PROGRESS_STEPS_3)
-
-    async def handle_event(self, kind: str, payload: dict) -> None:
-        if self._finished:
-            return
-        if kind == "status":
-            status = payload.get("status")
-            if status == "csv":
-                await self._set_step(1 if len(self._steps) > 1 else 0)
-            elif status == "report" and payload.get("format") == "xlsx":
-                if not self.has_filter and len(self._steps) > 1:
-                    await self._set_step(len(self._steps) - 1)
-        elif kind == "filter_start":
-            if self.has_filter:
-                await self._set_step(1)
-        elif kind == "filter_done":
-            if self.has_filter:
-                await self._set_step(2)
-
-    async def _set_step(self, index: int) -> None:
-        if index < 0 or index >= len(self._steps):
-            return
-        if index == self._current:
-            return
-        self._current = index
-        await self._progress.update_template(self._steps[index])
-
-    async def finish_success(self, *, delete_after: float | None = 45.0) -> None:
-        if self._finished:
-            return
-        self._finished = True
-        await self._progress.finish(DONE_TEXT, delete_after=delete_after)
-
-    async def fail(self) -> None:
-        if self._finished:
-            return
-        self._finished = True
-        await self._progress.fail(FAIL_TEXT)
 
 
 async def _start_report_progress(
     message: types.Message,
     include: list[str] | None = None,
     exclude: list[str] | None = None,
-) -> ReportProgressTracker:
-    steps = PROGRESS_STEPS_3 if (include or exclude) else PROGRESS_STEPS_2
-    progress = await ProgressMessage.create(message.bot, message.chat.id, steps[0])
-    return ReportProgressTracker(progress, steps)
+) -> ProgressReporter:
+    return create_report_progress(message.bot, message.chat.id)
+
+
+async def _close_progress_success(
+    tracker: ProgressReporter | None,
+    *,
+    delete_after: float | None = 45.0,
+) -> None:
+    if tracker:
+        await tracker.close(True, message=DONE_TEXT, delete_after=delete_after)
+
+
+async def _close_progress_fail(
+    tracker: ProgressReporter | None,
+    text: str = FAIL_TEXT,
+) -> None:
+    if tracker:
+        await tracker.close(False, message=text)
 
 
 def _is_timeout_error(exc: BaseException) -> bool:
@@ -592,7 +548,7 @@ async def _run_parser_bypass_validation(
         city=city,
         overrides=overrides,
     )
-    tracker: ReportProgressTracker | None = None
+    tracker: ProgressReporter | None = None
     decision: QuotaDecision | None = None
     result: parser_adapter.ReportResult | None = None
     try:
@@ -612,7 +568,10 @@ async def _run_parser_bypass_validation(
 
         async def _progress(kind: str, payload: dict) -> None:
             if tracker:
-                await tracker.handle_event(kind, payload)
+                try:
+                    await tracker.handle_event(kind, payload)
+                except Exception:  # pragma: no cover
+                    log.warning("report progress callback failed", exc_info=True)
 
         result = await parser_adapter.run_report(
             uid,
@@ -625,8 +584,7 @@ async def _run_parser_bypass_validation(
             **{k: v for k, v in overrides.items() if k not in {"include", "exclude"}},
         )
     except Exception as e:  # pragma: no cover
-        if tracker:
-            await tracker.fail()
+        await _close_progress_fail(tracker)
         event = "parse_timeout" if _is_timeout_error(e) else "parse_error"
         err_text = (str(e) or "").strip() or "Не удалось получить отчёт: парсер вернул ошибку. Попробуйте позже"
         log_event(event, level="ERROR", err=err_text)
@@ -647,11 +605,9 @@ async def _run_parser_bypass_validation(
                 exclude=overrides.get("exclude"),
                 reply_markup=_main_menu_kb(message, user=user),
             )
-            if tracker:
-                await tracker.finish_success()
+            await _close_progress_success(tracker)
         else:
-            if tracker:
-                await tracker.fail()
+            await _close_progress_fail(tracker)
             await message.answer("Отчёт не найден. Проверьте логи.", reply_markup=_main_menu_kb(message, user=user))
             log_event("parse_error", level="ERROR", err="report_missing")
             complete_operation(ok=False, err="report_missing")
@@ -702,7 +658,7 @@ async def _run_with_amount(
         approx_total=total,
     )
     decision: QuotaDecision | None = None
-    tracker: ReportProgressTracker | None = None
+    tracker: ProgressReporter | None = None
     result: parser_adapter.ReportResult | None = None
 
     try:
@@ -723,7 +679,10 @@ async def _run_with_amount(
 
         async def _progress(kind: str, payload: dict) -> None:
             if tracker:
-                await tracker.handle_event(kind, payload)
+                try:
+                    await tracker.handle_event(kind, payload)
+                except Exception:  # pragma: no cover
+                    log.warning("report progress callback failed", exc_info=True)
 
         run_kwargs = {k: v for k, v in ov.items() if k not in {"include", "exclude"}}
         result = await parser_adapter.run_report(
@@ -738,8 +697,7 @@ async def _run_with_amount(
             **run_kwargs,
         )
     except Exception as e:
-        if tracker:
-            await tracker.fail()
+        await _close_progress_fail(tracker)
         err_text = (str(e) or "").strip() or "Не удалось получить отчёт: парсер вернул ошибку. Попробуйте позже"
         event = "parse_timeout" if _is_timeout_error(e) else "parse_error"
         log_event(event, level="ERROR", err=err_text)
@@ -762,11 +720,9 @@ async def _run_with_amount(
                 exclude=ov.get("exclude"),
                 reply_markup=_main_menu_kb(message, user=user),
             )
-            if tracker:
-                await tracker.finish_success()
+            await _close_progress_success(tracker)
         else:
-            if tracker:
-                await tracker.fail()
+            await _close_progress_fail(tracker)
             await message.answer("Отчёт не найден. Проверьте логи.", reply_markup=_main_menu_kb(message, user=user))
             log_event("parse_error", level="ERROR", err="report_missing")
             complete_operation(ok=False, err="report_missing")
@@ -845,7 +801,7 @@ async def _run_parser(
             overrides=ov,
         )
         decision: QuotaDecision | None = None
-        tracker: ReportProgressTracker | None = None
+        tracker: ProgressReporter | None = None
         result: parser_adapter.ReportResult | None = None
         try:
             decision = await _ensure_quota(
@@ -864,7 +820,10 @@ async def _run_parser(
 
             async def _progress(kind: str, payload: dict) -> None:
                 if tracker:
-                    await tracker.handle_event(kind, payload)
+                    try:
+                        await tracker.handle_event(kind, payload)
+                    except Exception:  # pragma: no cover
+                        log.warning("report progress callback failed", exc_info=True)
 
             run_kwargs = {k: v for k, v in ov.items() if k not in {"include", "exclude"}}
             result = await parser_adapter.run_report(
@@ -901,11 +860,9 @@ async def _run_parser(
                     exclude=ov.get("exclude"),
                     reply_markup=_main_menu_kb(message, user=user),
                 )
-                if tracker:
-                    await tracker.finish_success()
+                await _close_progress_success(tracker)
             else:
-                if tracker:
-                    await tracker.fail()
+                await _close_progress_fail(tracker)
                 await message.answer("Отчёт не найден. Проверьте логи.", reply_markup=_main_menu_kb(message, user=user))
                 log_event("parse_error", level="ERROR", err="report_missing")
                 complete_operation(ok=False, err="report_missing")
@@ -1279,7 +1236,7 @@ async def cb_preview(call: types.CallbackQuery, state: FSMContext):
     if not await safe_answer(call, "Готовлю превью…", show_alert=False):
         return
 
-    progress: ProgressMessage | None = None
+    tracker: ProgressReporter | None = None
     try:
         payload = _PENDING_QTY.get(uid)   # ВАЖНО: .get(), НЕ .pop()!
         if not payload:
@@ -1309,8 +1266,16 @@ async def cb_preview(call: types.CallbackQuery, state: FSMContext):
             if not decision:
                 return
 
-        progress = await ProgressMessage.create(call.message.bot, call.message.chat.id, PREVIEW_TEMPLATE)
+        tracker = create_preview_progress(call.message.bot, call.message.chat.id)
         _log_preview_start(title, city, overrides)
+
+        async def _progress(kind: str, payload: dict) -> None:
+            if tracker:
+                try:
+                    await tracker.handle_event(kind, payload)
+                except Exception:  # pragma: no cover
+                    log.warning("preview progress callback failed", exc_info=True)
+
         try:
             preview_result = await parser_adapter.preview_rows(
                 uid,
@@ -1319,11 +1284,11 @@ async def cb_preview(call: types.CallbackQuery, state: FSMContext):
                 area=area_id,
                 include=include,
                 exclude=exclude,
+                progress=_progress,
             )
         except parser_adapter.DiagnosticError as exc:
             _log_preview_timeout(title, city, overrides, err=str(exc))
-            if progress:
-                await progress.fail()
+            await _close_progress_fail(tracker)
             await call.message.answer(
                 "Не получилось подготовить превью 😔\n"
                 "Попробуйте ещё раз позже.\n"
@@ -1333,8 +1298,7 @@ async def cb_preview(call: types.CallbackQuery, state: FSMContext):
             return
         except Exception as exc:
             _log_preview_timeout(title, city, overrides, err=str(exc))
-            if progress:
-                await progress.fail()
+            await _close_progress_fail(tracker)
             await call.message.answer("⏳ Превью не успело загрузиться. Попробуй ещё раз.")
             return
 
@@ -1342,8 +1306,7 @@ async def cb_preview(call: types.CallbackQuery, state: FSMContext):
         if not rows:
             await call.message.answer("Совпадений не нашлось по текущим критериям.")
             _log_preview_ready(title, city, 0, overrides)
-            if progress:
-                await progress.finish(DONE_TEXT, delete_after=45.0)
+            await _close_progress_success(tracker)
             return
 
         # аккуратный текст превью
@@ -1361,8 +1324,7 @@ async def cb_preview(call: types.CallbackQuery, state: FSMContext):
         txt = "<b>Предпросмотр (первые совпадения):</b>\n" + "\n".join(lines)
         await call.message.answer(txt, disable_web_page_preview=True)
         _log_preview_ready(title, city, len(rows), overrides)
-        if progress:
-            await progress.finish(DONE_TEXT, delete_after=45.0)
+        await _close_progress_success(tracker)
     finally:
         clear_busy(uid)
 

--- a/app/services/parser_adapter.py
+++ b/app/services/parser_adapter.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple
 
 from app.utils.diagnostics import write_bundle
-from app.utils.logging import log_event
+from app.utils.logging import get_operation_context, log_event
 
 log = logging.getLogger(__name__)
 
@@ -354,6 +354,7 @@ async def preview_rows(
     area: Optional[int] = None,
     include: Iterable[str] | str | None = None,
     exclude: Iterable[str] | str | None = None,
+    progress: ProgressCallback | None = None,
 ) -> PreviewResult:
     """Возвращает первые строки превью вместе с диагностикой."""
 
@@ -400,7 +401,62 @@ async def preview_rows(
         "exclude": exclude_list,
     }
 
+    STAGE_KEYS = ("preflight", "fetch", "normalize", "write_xlsx")
+    STAGE_WEIGHTS = {"preflight": 5.0, "fetch": 60.0, "normalize": 20.0, "write_xlsx": 15.0}
+    stage_progress: Dict[str, float] = {key: 0.0 for key in STAGE_KEYS}
+    progress_state: Dict[str, Any] = {
+        "percent": 0.0,
+        "stage": None,
+        "stages": {key: 0.0 for key in STAGE_KEYS},
+    }
+    ctx = get_operation_context()
+    correlation_id = ctx.correlation_id if ctx else str(uuid.uuid4())
+
+    async def _emit(event: str, payload: dict) -> None:
+        if not progress:
+            return
+        try:
+            await progress(event, payload)
+        except Exception:  # pragma: no cover
+            log.warning("preview progress callback failed", exc_info=True)
+
+    def _update(stage: str, value: float) -> None:
+        if stage not in stage_progress:
+            return
+        val = max(0.0, min(1.0, value))
+        if val >= stage_progress[stage]:
+            stage_progress[stage] = val
+        percent = 0.0
+        for key, weight in STAGE_WEIGHTS.items():
+            percent += weight * stage_progress[key]
+        if stage_progress["write_xlsx"] < 1.0:
+            percent = min(percent, 99.0)
+        progress_state["percent"] = round(percent, 2)
+        progress_state["stage"] = stage
+        progress_state["stages"] = {key: round(val, 4) for key, val in stage_progress.items()}
+
+    def _progress_snapshot() -> Dict[str, Any]:
+        return {
+            "percent": progress_state.get("percent"),
+            "stage": progress_state.get("stage"),
+            "stages": dict(progress_state.get("stages", {})),
+        }
+
+    _update("preflight", 1.0)
+    if progress:
+        await _emit(
+            "start",
+            {
+                "correlation_id": correlation_id,
+                "mode": "preview",
+                "site": "hh",
+            },
+        )
+        await _emit("update", {"stage": "preflight", "subprogress": 1.0})
+
     try:
+        _update("fetch", 0.1)
+        await _emit("update", {"stage": "fetch", "subprogress": 0.1})
         rows_raw = await preview_report(
             user_id,
             query,
@@ -410,6 +466,8 @@ async def preview_rows(
             exclude=exclude,
             diagnostic=diagnostic,
         )
+        _update("fetch", 1.0)
+        await _emit("update", {"stage": "fetch", "subprogress": 1.0})
     except Exception as exc:
         stack_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
         error_meta = dict(base_meta)
@@ -423,6 +481,7 @@ async def preview_rows(
                 "returncode": diagnostic.get("returncode"),
             }
         )
+        error_meta["progress"] = _progress_snapshot()
         bundle = write_bundle(
             user_dir,
             bundle_prefix,
@@ -488,6 +547,13 @@ async def preview_rows(
                 }
             )
 
+    _update("normalize", 1.0)
+    await _emit("update", {"stage": "normalize", "subprogress": 1.0})
+
+    if stage_progress["write_xlsx"] < 0.2:
+        _update("write_xlsx", 0.2)
+        await _emit("update", {"stage": "write_xlsx", "subprogress": 0.2})
+
     success_meta = dict(base_meta)
     success_meta.update(
         {
@@ -500,6 +566,9 @@ async def preview_rows(
             "error": diagnostic.get("error"),
         }
     )
+    _update("write_xlsx", 1.0)
+    await _emit("update", {"stage": "write_xlsx", "subprogress": 1.0})
+    success_meta["progress"] = _progress_snapshot()
 
     bundle = write_bundle(
         user_dir,
@@ -619,6 +688,81 @@ async def run_report(
     }
     bundle_prefix = f"report_{uuid.uuid4().hex[:6]}"
 
+    STAGE_KEYS = ("preflight", "fetch", "normalize", "write_xlsx")
+    STAGE_WEIGHTS = {"preflight": 5.0, "fetch": 60.0, "normalize": 20.0, "write_xlsx": 15.0}
+    stage_progress: Dict[str, float] = {key: 0.0 for key in STAGE_KEYS}
+    progress_state: Dict[str, Any] = {
+        "percent": 0.0,
+        "pages_done": 0,
+        "pages_total": pages or 0,
+        "stage": None,
+        "stages": {key: 0.0 for key in STAGE_KEYS},
+    }
+    ctx = get_operation_context()
+    correlation_id = ctx.correlation_id if ctx else str(uuid.uuid4())
+
+    async def _emit(event: str, payload: dict) -> None:
+        if not progress:
+            return
+        try:
+            await progress(event, payload)
+        except Exception:  # pragma: no cover
+            log.warning("progress callback failed", exc_info=True)
+
+    def _update_snapshot(
+        stage: str,
+        subprogress: float,
+        *,
+        pages_done: int | None = None,
+        pages_total: int | None = None,
+    ) -> None:
+        if stage not in stage_progress:
+            return
+        value = max(0.0, min(1.0, subprogress))
+        if value >= stage_progress[stage]:
+            stage_progress[stage] = value
+        if pages_total is not None and pages_total > 0:
+            progress_state["pages_total"] = pages_total
+        if pages_done is not None and pages_done >= 0:
+            progress_state["pages_done"] = pages_done
+        percent = 0.0
+        for key, weight in STAGE_WEIGHTS.items():
+            percent += weight * min(1.0, stage_progress[key])
+        if stage_progress["write_xlsx"] < 1.0:
+            percent = min(percent, 99.0)
+        progress_state["percent"] = round(percent, 2)
+        progress_state["stage"] = stage
+        progress_state["stages"] = {key: round(val, 4) for key, val in stage_progress.items()}
+
+    def _progress_snapshot() -> Dict[str, Any]:
+        return {
+            "percent": progress_state.get("percent"),
+            "stage": progress_state.get("stage"),
+            "pages_done": progress_state.get("pages_done"),
+            "pages_total": progress_state.get("pages_total"),
+            "stages": dict(progress_state.get("stages", {})),
+        }
+
+    _update_snapshot("preflight", 1.0, pages_total=pages)
+    if progress:
+        await _emit(
+            "start",
+            {
+                "correlation_id": correlation_id,
+                "mode": "report",
+                "pages_total": pages,
+                "site": site,
+            },
+        )
+        await _emit(
+            "update",
+            {
+                "stage": "preflight",
+                "subprogress": 1.0,
+                "pages_total": pages,
+            },
+        )
+
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -635,20 +779,51 @@ async def run_report(
                     break
                 text_line = line.decode(errors="ignore").rstrip("\r\n")
                 stdout_lines.append(text_line)
-                if progress:
+                try:
+                    payload = json.loads(text_line)
+                except json.JSONDecodeError:
+                    continue
+                status = payload.get("status")
+                if status == "fetch_progress":
+                    pages_done = int(payload.get("pages_done") or 0)
+                    pages_total = int(payload.get("pages_total") or 0) or progress_state.get("pages_total") or (pages or 0)
+                    sub = float(pages_done / pages_total) if pages_total else 0.0
+                    _update_snapshot("fetch", sub, pages_done=pages_done, pages_total=pages_total)
+                    await _emit(
+                        "update",
+                        {
+                            "stage": "fetch",
+                            "subprogress": sub,
+                            "pages_done": pages_done,
+                            "pages_total": pages_total,
+                        },
+                    )
+                    continue
+                if status == "csv" and payload.get("path"):
                     try:
-                        payload = json.loads(text_line)
-                    except json.JSONDecodeError:
-                        continue
-                    if payload.get("status") == "csv" and payload.get("path"):
-                        try:
-                            csv_path = Path(payload["path"])
-                        except Exception:  # pragma: no cover
-                            csv_path = None
-                    try:
-                        await progress("status", payload)
+                        csv_path = Path(payload["path"])
                     except Exception:  # pragma: no cover
-                        log.warning("progress callback failed", exc_info=True)
+                        csv_path = None
+                    total_pages = progress_state.get("pages_total") or (pages or 0)
+                    done_pages = progress_state.get("pages_done") or total_pages
+                    _update_snapshot("fetch", 1.0, pages_done=done_pages, pages_total=total_pages)
+                    await _emit(
+                        "update",
+                        {
+                            "stage": "fetch",
+                            "subprogress": 1.0,
+                            "pages_done": done_pages,
+                            "pages_total": total_pages,
+                        },
+                    )
+                    if stage_progress["normalize"] < 0.05:
+                        _update_snapshot("normalize", 0.05)
+                        await _emit("update", {"stage": "normalize", "subprogress": 0.05})
+                    continue
+                if status == "report" and payload.get("format") == "xlsx":
+                    _update_snapshot("write_xlsx", 1.0)
+                    await _emit("update", {"stage": "write_xlsx", "subprogress": 1.0})
+                    continue
 
         async def _read_stderr() -> None:
             assert proc.stderr is not None
@@ -685,24 +860,36 @@ async def run_report(
             )
 
         if inc or exc:
-            if progress:
-                try:
-                    await progress("filter_start", {"csv_path": str(csv_path) if csv_path else None})
-                except Exception:  # pragma: no cover
-                    log.warning("progress callback failed on filter_start", exc_info=True)
+            if stage_progress["normalize"] < 0.2:
+                _update_snapshot("normalize", 0.2)
+                await _emit("update", {"stage": "normalize", "subprogress": 0.2})
             await asyncio.to_thread(_postfilter_any, out_path, inc, exc, csv_path=csv_path)
-            if progress:
-                try:
-                    await progress("filter_done", {"csv_path": str(csv_path) if csv_path else None})
-                except Exception:  # pragma: no cover
-                    log.warning("progress callback failed on filter_done", exc_info=True)
+            _update_snapshot("normalize", 1.0)
+            await _emit(
+                "update",
+                {
+                    "stage": "normalize",
+                    "subprogress": 1.0,
+                    "csv_path": str(csv_path) if csv_path else None,
+                },
+            )
+        else:
+            if stage_progress["normalize"] < 1.0:
+                _update_snapshot("normalize", 1.0)
+                await _emit("update", {"stage": "normalize", "subprogress": 1.0})
+
+        if stage_progress["write_xlsx"] < 0.2:
+            _update_snapshot("write_xlsx", 0.2)
+            await _emit("update", {"stage": "write_xlsx", "subprogress": 0.2})
 
         bundle_meta["csv_path"] = str(csv_path) if csv_path else None
+        bundle_meta["progress"] = _progress_snapshot()
     except Exception as exc:
         stack_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
         error_meta = dict(bundle_meta)
         error_meta["status"] = "error"
         error_meta["error"] = str(exc)
+        error_meta["progress"] = _progress_snapshot()
         bundle = write_bundle(
             user_dir,
             bundle_prefix,
@@ -729,6 +916,7 @@ async def run_report(
 
     success_meta = dict(bundle_meta)
     success_meta["status"] = "ok"
+    success_meta["progress"] = _progress_snapshot()
     bundle = write_bundle(
         user_dir,
         bundle_prefix,

--- a/app/utils/progress.py
+++ b/app/utils/progress.py
@@ -1,113 +1,319 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Sequence
+import time
+from dataclasses import dataclass
+from typing import Dict, Sequence
 
 from aiogram import Bot
 from aiogram.utils.exceptions import MessageCantBeEdited, MessageNotModified
 
+from app.utils.logging import get_operation_context, log_event
+
+
+@dataclass(frozen=True)
+class StageDefinition:
+    key: str
+    weight: float
+    label: str
+    fallback_active: int | None = None
+    fallback_done: int | None = None
+
+
+@dataclass
+class _StageState:
+    definition: StageDefinition
+    progress: float = 0.0
+    started_at: float | None = None
+    completed_at: float | None = None
+    done_reported: bool = False
+
+    def mark_start(self) -> None:
+        if self.started_at is None:
+            self.started_at = time.perf_counter()
+
+    def mark_done(self) -> None:
+        if self.completed_at is None:
+            self.completed_at = time.perf_counter()
+
+    @property
+    def is_done(self) -> bool:
+        return self.progress >= 1.0
+
 
 class ProgressMessage:
-    """Utility to manage a single editable progress message with spinner."""
+    """Wrapper around a single editable Telegram message used for progress."""
 
-    _SPINNER: Sequence[str] = ("⏳", "⌛", "🔄")
+    def __init__(self, bot: Bot, chat_id: int, message_id: int) -> None:
+        self._bot = bot
+        self._chat_id = chat_id
+        self._message_id = message_id
+
+    @classmethod
+    async def create(cls, bot: Bot, chat_id: int, text: str) -> "ProgressMessage":
+        message = await bot.send_message(chat_id, text)
+        return cls(bot, chat_id, message.message_id)
+
+    async def edit(self, text: str) -> None:
+        try:
+            await self._bot.edit_message_text(text, self._chat_id, self._message_id)
+        except (MessageNotModified, MessageCantBeEdited):
+            pass
+        except Exception:  # pragma: no cover - network errors are ignored
+            pass
+
+    async def delete_after(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+        try:
+            await self._bot.delete_message(self._chat_id, self._message_id)
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+REPORT_STAGES: Sequence[StageDefinition] = (
+    StageDefinition("preflight", 5.0, "инициализация", fallback_done=10),
+    StageDefinition(
+        "fetch",
+        60.0,
+        "парсинг страниц",
+        fallback_active=30,
+        fallback_done=60,
+    ),
+    StageDefinition("normalize", 20.0, "нормализация", fallback_done=90),
+    StageDefinition("write_xlsx", 15.0, "сбор XLSX", fallback_active=90, fallback_done=99),
+)
+
+PREVIEW_STAGES: Sequence[StageDefinition] = REPORT_STAGES
+
+
+class ProgressReporter:
+    """Aggregates stage-based progress and renders a single Telegram message."""
 
     def __init__(
         self,
         bot: Bot,
         chat_id: int,
-        message_id: int,
-        template: str,
         *,
-        interval: float = 3.0,
+        title: str,
+        stages: Sequence[StageDefinition],
+        update_interval: float = 2.0,
+        min_delta: float = 1.0,
     ) -> None:
         self._bot = bot
         self._chat_id = chat_id
-        self._message_id = message_id
-        self._template = template
-        self._interval = interval
-        self._spinner_index = 0
-        self._active = True
+        self._title = title
+        self._stage_states = [_StageState(stage) for stage in stages]
+        self._stage_map: Dict[str, _StageState] = {state.definition.key: state for state in self._stage_states}
+        self._update_interval = update_interval
+        self._min_delta = min_delta
+        self._message: ProgressMessage | None = None
+        self._last_sent_percent: float = -1.0
+        self._last_sent_ts: float = 0.0
+        self._current_percent: float = 0.0
+        self._pages_total: int | None = None
+        self._pages_done: int | None = None
+        self._pages_known = False
+        self._site: str | None = None
         self._lock = asyncio.Lock()
-        self._spin_task: asyncio.Task | None = None
+        self._finalized = False
+        self._started_at = time.perf_counter()
+        self._correlation_id: str | None = None
 
-    @classmethod
-    async def create(
-        cls,
-        bot: Bot,
-        chat_id: int,
-        template: str,
+    async def handle_event(self, kind: str, payload: dict) -> None:
+        if kind == "start":
+            await self._handle_start(payload)
+        elif kind == "update":
+            await self._handle_update(payload)
+        elif kind == "close":
+            await self.close(payload.get("ok", True), message=payload.get("message"), delete_after=payload.get("delete_after"))
+
+    async def close(
+        self,
+        ok: bool,
         *,
-        interval: float = 3.0,
-    ) -> "ProgressMessage":
-        text = template.format(spinner=cls._SPINNER[0])
-        message = await bot.send_message(chat_id, text)
-        inst = cls(bot, chat_id, message.message_id, template, interval=interval)
-        inst._spin_task = asyncio.create_task(inst._spin())
-        return inst
-
-    async def update_template(self, template: str) -> None:
-        self._template = template
-        self._spinner_index = 0
-        await self._render_current()
-
-    async def _render_current(self) -> None:
-        if not self._active:
-            return
+        message: str | None = None,
+        delete_after: float | None = None,
+    ) -> None:
         async with self._lock:
-            text = self._template.format(spinner=self._SPINNER[self._spinner_index])
-            try:
-                await self._bot.edit_message_text(text, self._chat_id, self._message_id)
-            except (MessageNotModified, MessageCantBeEdited):
-                pass
-            except Exception:  # pragma: no cover
-                pass
+            if self._finalized:
+                return
+            self._finalized = True
+            duration_ms = int((time.perf_counter() - self._started_at) * 1000)
+            if ok:
+                self._current_percent = 100.0
+            log_event(
+                "progress_close",
+                ok=ok,
+                percent=int(round(self._current_percent)),
+                duration_ms=duration_ms,
+            )
+            if self._message is None:
+                return
+            text = message or ("✅ Готово" if ok else "❌ Что-то пошло не так")
+            await self._message.edit(text)
+            if delete_after:
+                asyncio.create_task(self._message.delete_after(delete_after))
 
-    async def _spin(self) -> None:
-        try:
-            while self._active:
-                await asyncio.sleep(self._interval)
-                if not self._active:
-                    break
-                self._spinner_index = (self._spinner_index + 1) % len(self._SPINNER)
-                await self._render_current()
-        except asyncio.CancelledError:  # pragma: no cover
-            raise
+    async def _handle_start(self, payload: dict) -> None:
+        async with self._lock:
+            if self._message is not None:
+                return
+            ctx = get_operation_context()
+            self._correlation_id = payload.get("correlation_id") or (ctx.correlation_id if ctx else None)
+            self._site = payload.get("site")
+            self._started_at = time.perf_counter()
+            pages_total = payload.get("pages_total")
+            if isinstance(pages_total, int) and pages_total > 0:
+                self._pages_total = pages_total
+                self._pages_known = True
+            fetch_state = self._stage_map.get("fetch")
+            if fetch_state and self._site:
+                fetch_state.definition = StageDefinition(
+                    fetch_state.definition.key,
+                    fetch_state.definition.weight,
+                    f"{fetch_state.definition.label} {self._site}",
+                    fallback_active=fetch_state.definition.fallback_active,
+                    fallback_done=fetch_state.definition.fallback_done,
+                )
+            self._message = await ProgressMessage.create(self._bot, self._chat_id, self._render_text(0.0))
+            self._last_sent_percent = 0.0
+            self._last_sent_ts = time.perf_counter() - self._update_interval
+            log_event(
+                "progress_start",
+                stage="preflight",
+                percent=0,
+                site=self._site,
+                pages_total=self._pages_total,
+            )
 
-    async def finish(self, text: str, *, delete_after: float | None = None) -> None:
-        await self._stop()
-        try:
-            await self._bot.edit_message_text(text, self._chat_id, self._message_id)
-        except (MessageNotModified, MessageCantBeEdited):
-            pass
-        except Exception:  # pragma: no cover
-            pass
-        if delete_after:
-            asyncio.create_task(self._delete_later(delete_after))
-
-    async def fail(self, text: str) -> None:
-        await self._stop()
-        try:
-            await self._bot.edit_message_text(text, self._chat_id, self._message_id)
-        except (MessageNotModified, MessageCantBeEdited):
-            pass
-        except Exception:  # pragma: no cover
-            pass
-
-    async def _stop(self) -> None:
-        if not self._active:
+    async def _handle_update(self, payload: dict) -> None:
+        stage = payload.get("stage")
+        if not stage or stage not in self._stage_map:
             return
-        self._active = False
-        if self._spin_task:
-            self._spin_task.cancel()
-            try:
-                await self._spin_task
-            except asyncio.CancelledError:
-                pass
+        state = self._stage_map[stage]
+        subprogress = float(payload.get("subprogress", 0.0))
+        subprogress = max(0.0, min(1.0, subprogress))
 
-    async def _delete_later(self, delay: float) -> None:
-        await asyncio.sleep(delay)
-        try:
-            await self._bot.delete_message(self._chat_id, self._message_id)
-        except Exception:  # pragma: no cover
-            pass
+        pages_total = payload.get("pages_total")
+        if isinstance(pages_total, int) and pages_total > 0:
+            self._pages_total = pages_total
+            self._pages_known = True
+        pages_done = payload.get("pages_done")
+        if isinstance(pages_done, int) and pages_done >= 0:
+            self._pages_done = pages_done
+
+        async with self._lock:
+            if state.progress == 0.0 and subprogress > 0.0:
+                state.mark_start()
+                log_event("progress_stage_start", stage=stage)
+            if subprogress >= state.progress:
+                state.progress = subprogress
+            if state.progress >= 1.0:
+                if not state.is_done:
+                    state.progress = 1.0
+                state.mark_done()
+            percent = self._compute_percent(stage)
+            now = time.perf_counter()
+            should_render = False
+            if self._message is None:
+                return
+            if percent - self._last_sent_percent >= self._min_delta:
+                if now - self._last_sent_ts >= self._update_interval:
+                    should_render = True
+            if should_render:
+                self._current_percent = percent
+                self._last_sent_percent = percent
+                self._last_sent_ts = now
+                await self._message.edit(self._render_text(percent))
+            log_event(
+                "progress_update",
+                stage=stage,
+                stage_progress=round(state.progress, 4),
+                percent=int(round(percent)),
+                pages_done=self._pages_done,
+                pages_total=self._pages_total,
+            )
+            if state.completed_at and state.is_done and not state.done_reported:
+                duration = None
+                if state.started_at:
+                    duration = int((state.completed_at - state.started_at) * 1000)
+                log_event(
+                    "progress_stage_done",
+                    stage=stage,
+                    duration_ms=duration,
+                    pages_done=self._pages_done,
+                    pages_total=self._pages_total,
+                )
+                state.done_reported = True
+
+    def _compute_percent(self, stage: str) -> float:
+        if not self._pages_known:
+            return self._compute_fallback_percent(stage)
+        percent = 0.0
+        for state in self._stage_states:
+            percent += state.definition.weight * max(0.0, min(1.0, state.progress))
+        if not self._finalized:
+            percent = min(percent, 99.0)
+        return max(self._current_percent, round(percent, 2))
+
+    def _compute_fallback_percent(self, stage: str) -> float:
+        percent = self._current_percent
+        state = self._stage_map[stage]
+        fallback_active = state.definition.fallback_active
+        fallback_done = state.definition.fallback_done
+        if state.progress >= 1.0 and fallback_done is not None:
+            percent = max(percent, float(fallback_done))
+        elif state.progress > 0.0 and fallback_active is not None:
+            percent = max(percent, float(fallback_active))
+        if not self._finalized:
+            percent = min(percent, 99.0)
+        return percent
+
+    def _render_text(self, percent: float) -> str:
+        active_stage = self._resolve_active_stage()
+        header = f"⏳ {self._title}… {int(round(percent))}%"
+        lines = [header]
+        for state in self._stage_states:
+            prefix = "—"
+            if state.is_done:
+                prefix = "✓"
+            elif state.definition.key == active_stage:
+                prefix = "→"
+            label = state.definition.label
+            if state.definition.key == "fetch" and self._pages_total:
+                done = self._pages_done or 0
+                label = f"{label}… {done}/{self._pages_total}"
+            else:
+                label = f"{label}…"
+            lines.append(f"{prefix} {label}")
+        return "\n".join(lines)
+
+    def _resolve_active_stage(self) -> str | None:
+        for state in self._stage_states:
+            if state.progress < 1.0:
+                return state.definition.key
+        return None
+
+    def snapshot(self) -> dict:
+        return {
+            "percent": round(self._current_percent, 2),
+            "site": self._site,
+            "pages_done": self._pages_done,
+            "pages_total": self._pages_total,
+            "stages": {
+                state.definition.key: {
+                    "progress": round(state.progress, 4),
+                    "started_at": state.started_at,
+                    "completed_at": state.completed_at,
+                }
+                for state in self._stage_states
+            },
+        }
+
+
+def create_report_progress(bot: Bot, chat_id: int) -> ProgressReporter:
+    return ProgressReporter(bot, chat_id, title="Готовлю данные", stages=REPORT_STAGES)
+
+
+def create_preview_progress(bot: Bot, chat_id: int) -> ProgressReporter:
+    return ProgressReporter(bot, chat_id, title="Готовлю превью", stages=PREVIEW_STAGES)

--- a/vendor/parser_tdnm/parsers/fetch_vacancies.py
+++ b/vendor/parser_tdnm/parsers/fetch_vacancies.py
@@ -1,5 +1,5 @@
 # parsers/fetch_vacancies.py
-import time, argparse, pandas as pd, re, urllib.parse, html
+import time, argparse, pandas as pd, re, urllib.parse, html, json
 from typing import List, Dict, Any, Tuple, Optional
 
 try:  # pragma: no cover - import shim for script execution
@@ -309,6 +309,7 @@ def pick_benefits(text: str) -> Optional[str]:
 # =================== HH.RU ===================
 def hh_search(query: str, area: int, pages: int, per_page: int, pause: float, search_in: str) -> List[Dict[str, Any]]:
     items=[]
+    total_pages = max(1, pages)
     for page in range(pages):
         p={"text":query,"area":area,"page":page,"per_page":per_page,"only_with_salary":"false"}
         if search_in in ("name","description","company_name","everything"):
@@ -316,7 +317,15 @@ def hh_search(query: str, area: int, pages: int, per_page: int, pause: float, se
         r=requests.get("https://api.hh.ru/vacancies", params=p, headers=HEADERS, timeout=20)
         if r.status_code!=200: break
         data=r.json(); items+=data.get("items",[])
-        if page>=data.get("pages",0)-1: break
+        api_pages = data.get("pages")
+        if isinstance(api_pages, int) and api_pages > 0:
+            total_pages = max(1, min(pages, api_pages))
+        done_pages = min(page + 1, total_pages)
+        try:
+            print(json.dumps({"status": "fetch_progress", "pages_done": done_pages, "pages_total": total_pages}), flush=True)
+        except Exception:
+            pass
+        if page>= (api_pages if isinstance(api_pages, int) and api_pages > 0 else total_pages) -1: break
         time.sleep(pause)
     return items
 


### PR DESCRIPTION
## Summary
- add a reusable `ProgressReporter` to render weighted stage percentages in a single progress message
- emit structured progress updates from the report/preview pipelines and persist snapshots in diagnostic bundles
- wire Telegram handlers and the fetch script to relay the new progress events and close out the UI cleanly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d675cfbe4883209604512c68a8194f