### PR TITLE
Add promo code redemption flow and admin management

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 import asyncio
 from datetime import datetime
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from aiogram import types, Dispatcher
+from aiogram.dispatcher import FSMContext
+from aiogram.dispatcher.filters.state import State, StatesGroup
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, InputFile
 from aiogram.utils.exceptions import BotBlocked, ChatNotFound, RetryAfter, MessageNotModified
 from pathlib import Path
 
-from app.storage import repo
+from peewee import IntegrityError
+
+from app.storage import promo_repo, repo
 from app.storage.models import User
-from app.services import referrals as referral_service
+from app.services import promo as promo_service, referrals as referral_service
 from app.utils.backup import make_sqlite_backup
 from app.utils.admins import is_admin
 from app.utils.callbacks import safe_answer
@@ -28,6 +32,7 @@ def _kb_admin_home() -> InlineKeyboardMarkup:
         InlineKeyboardButton("📣 Рассылка", callback_data="admin_cast"),
     )
     kb.add(InlineKeyboardButton("🎯 Рефералы", callback_data="admin_ref"))
+    kb.add(InlineKeyboardButton("🎟 Промокоды", callback_data="admin_promo"))
     kb.add(InlineKeyboardButton("💾 Бэкап БД", callback_data="admin_backup"))
     return kb
 
@@ -40,6 +45,18 @@ async def _safe_edit_text(message: types.Message, text: str, **kwargs) -> None:
 
 # message_id -> целевой user_id для точечной рассылки
 _CAST_TARGETS: dict[int, int] = {}
+
+
+class PromoCreateForm(StatesGroup):
+    waiting_code = State()
+    waiting_bonus = State()
+    waiting_period = State()
+    waiting_limit = State()
+    confirm = State()
+
+
+class PromoSearchForm(StatesGroup):
+    waiting_query = State()
 
 
 def _users_page(page: int, q: str | None = None) -> Tuple[str, InlineKeyboardMarkup]:
@@ -244,6 +261,397 @@ async def cb_referral_reject(call: types.CallbackQuery):
     if ok:
         await cb_referral_card(call)
 
+# -------- промокоды --------
+def _promo_home_text() -> str:
+    return "🎟 <b>Промокоды</b>\nВыберите действие."
+
+
+def _kb_promo_home() -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(InlineKeyboardButton("➕ Создать промокод", callback_data="admin_promo_create"))
+    kb.add(InlineKeyboardButton("📊 Статистика", callback_data="admin_promo_stats:1"))
+    kb.add(InlineKeyboardButton("🔎 Найти код", callback_data="admin_promo_search"))
+    kb.add(InlineKeyboardButton("⬅️ Назад", callback_data="admin_home"))
+    return kb
+
+
+def _format_period(starts_at: Optional[datetime], expires_at: Optional[datetime]) -> str:
+    if not starts_at and not expires_at:
+        return "без срока"
+    parts: List[str] = []
+    if starts_at:
+        parts.append(f"с {starts_at:%Y-%m-%d}")
+    if expires_at:
+        parts.append(f"до {expires_at:%Y-%m-%d}")
+    return " ".join(parts)
+
+
+def _format_limit(promo) -> str:
+    limit = "∞" if promo.max_redemptions is None else str(promo.max_redemptions)
+    return f"{promo.redemptions_count}/{limit}"
+
+
+def _promo_stats_page(page: int, search: str | None = None) -> Tuple[str, InlineKeyboardMarkup]:
+    total = promo_repo.count_codes(search)
+    pages = max(1, (total + PAGE_SIZE - 1) // PAGE_SIZE)
+    page = max(1, min(page, pages))
+    codes = promo_repo.list_codes(offset=(page - 1) * PAGE_SIZE, limit=PAGE_SIZE, search=search)
+
+    title = "📊 Промокоды"
+    if search:
+        title += f" по запросу «{search}»"
+    title += f" — страница {page}/{pages} (всего: {total})"
+
+    lines = [title]
+    kb = InlineKeyboardMarkup(row_width=1)
+    for item in codes:
+        status = "🟢" if item.is_active else "🔴"
+        expires = item.expires_at.strftime("%Y-%m-%d") if item.expires_at else "—"
+        lines.append(
+            f"{status} {item.code} • +{item.bonus_credits} • активировано: {_format_limit(item)} • до: {expires}"
+        )
+        kb.add(InlineKeyboardButton(item.code[:64], callback_data=f"admin_promo_view:{item.code}"))
+
+    if not codes:
+        lines.append("Коды не найдены.")
+
+    nav: List[InlineKeyboardButton] = []
+    if page > 1:
+        nav.append(InlineKeyboardButton("◀️", callback_data=f"admin_promo_stats:{page-1}"))
+    nav.append(InlineKeyboardButton("🔄", callback_data=f"admin_promo_stats:{page}"))
+    if page < pages:
+        nav.append(InlineKeyboardButton("▶️", callback_data=f"admin_promo_stats:{page+1}"))
+    if nav:
+        kb.row(*nav)
+
+    kb.add(InlineKeyboardButton("⬅️ Назад", callback_data="admin_promo"))
+    return "\n".join(lines), kb
+
+
+def _promo_card_text(promo) -> str:
+    counts = promo_repo.redemption_counts(promo)
+    lines = [
+        "🎟 <b>Промокод</b>",
+        f"Код: <code>{promo.code}</code>",
+        f"Бонус: +{promo.bonus_credits} кредитов",
+        f"Статус: {'активен' if promo.is_active else 'выключен'}",
+        f"Период: {_format_period(promo.starts_at, promo.expires_at)}",
+        f"Лимит: {_format_limit(promo)}",
+        f"Всего активаций: {counts['total']}",
+        f"За 7 дней: {counts['last7']}, за 30 дней: {counts['last30']}",
+        f"Создан: {promo.created_at:%Y-%m-%d %H:%M} UTC",
+        f"Создал: <code>{promo.created_by}</code>",
+    ]
+    if promo.title:
+        lines.insert(1, f"Название: {promo.title}")
+    return "\n".join(lines)
+
+
+def _kb_promo_card(promo) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=2)
+    toggle_text = "🔴 Выключить" if promo.is_active else "🟢 Включить"
+    kb.add(InlineKeyboardButton(toggle_text, callback_data=f"admin_promo_toggle:{promo.code}"))
+    kb.add(InlineKeyboardButton("🗑 Удалить", callback_data=f"admin_promo_delete:{promo.code}"))
+    kb.add(InlineKeyboardButton("📊 К списку", callback_data="admin_promo_stats:1"))
+    kb.add(InlineKeyboardButton("⬅️ Меню", callback_data="admin_promo"))
+    return kb
+
+
+async def cb_promo_home(call: types.CallbackQuery):
+    if not _guard(call.from_user.id):
+        return
+    await _safe_edit_text(call.message, _promo_home_text(), reply_markup=_kb_promo_home(), parse_mode="HTML")
+    if not await safe_answer(call):
+        return
+
+
+async def cb_promo_stats(call: types.CallbackQuery):
+    if not _guard(call.from_user.id):
+        return
+    parts = call.data.split(":", 1)
+    page = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 1
+    text, kb = _promo_stats_page(page)
+    await _safe_edit_text(call.message, text, reply_markup=kb)
+    if not await safe_answer(call):
+        return
+
+
+async def cb_promo_view(call: types.CallbackQuery):
+    if not _guard(call.from_user.id):
+        return
+    _, code = call.data.split(":", 1)
+    promo = promo_repo.get_by_code(code)
+    if not promo:
+        await safe_answer(call, "Промокод не найден", show_alert=True)
+        return
+    await _safe_edit_text(call.message, _promo_card_text(promo), reply_markup=_kb_promo_card(promo), parse_mode="HTML")
+    if not await safe_answer(call):
+        return
+
+
+async def cb_promo_toggle(call: types.CallbackQuery):
+    if not _guard(call.from_user.id):
+        return
+    _, code = call.data.split(":", 1)
+    promo = promo_repo.get_by_code(code)
+    if not promo:
+        await safe_answer(call, "Промокод не найден", show_alert=True)
+        return
+    new_state = not promo.is_active
+    promo_repo.set_active(code, new_state)
+    log_event(
+        "promo_toggle",
+        message="Promo toggled",
+        code=code,
+        active=new_state,
+        actor=call.from_user.id,
+    )
+    promo = promo_repo.get_by_code(code)
+    await _safe_edit_text(call.message, _promo_card_text(promo), reply_markup=_kb_promo_card(promo), parse_mode="HTML")
+    if not await safe_answer(call, "Статус обновлён", show_alert=False):
+        return
+
+
+async def cb_promo_delete(call: types.CallbackQuery):
+    if not _guard(call.from_user.id):
+        return
+    _, code = call.data.split(":", 1)
+    promo = promo_repo.get_by_code(code)
+    if not promo:
+        await safe_answer(call, "Промокод не найден", show_alert=True)
+        return
+    ok = promo_repo.delete_code(code)
+    if not ok:
+        await safe_answer(call, "Можно только выключить", show_alert=True)
+        return
+    log_event("promo_deleted", message="Promo deleted", code=code, actor=call.from_user.id)
+    await _safe_edit_text(call.message, _promo_home_text(), reply_markup=_kb_promo_home(), parse_mode="HTML")
+    if not await safe_answer(call, "Удалено", show_alert=False):
+        return
+
+
+async def cb_promo_search(call: types.CallbackQuery, state: FSMContext):
+    if not _guard(call.from_user.id):
+        return
+    await state.set_state(PromoSearchForm.waiting_query.state)
+    await call.message.answer("Введите часть кода или «отмена» для выхода.")
+    if not await safe_answer(call):
+        return
+
+
+async def promo_search_query(message: types.Message, state: FSMContext):
+    query = (message.text or "").strip()
+    if not query or query.lower() in {"отмена", "/cancel"}:
+        await state.finish()
+        await message.reply("Поиск отменён.")
+        return
+    results = promo_repo.search_codes(query, limit=10)
+    kb = InlineKeyboardMarkup(row_width=1)
+    if results:
+        text_lines = [f"Найдено {len(results)} код(ов):"]
+        for item in results:
+            status = "🟢" if item.is_active else "🔴"
+            text_lines.append(f"{status} {item.code} — +{item.bonus_credits} кредитов")
+            kb.add(InlineKeyboardButton(item.code[:64], callback_data=f"admin_promo_view:{item.code}"))
+    else:
+        text_lines = ["Коды не найдены."]
+    kb.add(InlineKeyboardButton("⬅️ Меню", callback_data="admin_promo"))
+    await message.reply("\n".join(text_lines), reply_markup=kb)
+    await state.finish()
+
+
+async def cb_promo_create(call: types.CallbackQuery, state: FSMContext):
+    if not _guard(call.from_user.id):
+        return
+    await state.update_data(created_by=call.from_user.id)
+    await state.set_state(PromoCreateForm.waiting_code.state)
+    await call.message.answer("Введите CODE (латиница/цифры/дефис, до 24 символов).")
+    if not await safe_answer(call):
+        return
+
+
+async def promo_create_code(message: types.Message, state: FSMContext):
+    raw = (message.text or "").strip()
+    if raw.lower() in {"/cancel", "отмена"}:
+        await state.finish()
+        await message.reply("Создание промокода отменено.")
+        return
+    try:
+        code = promo_service.normalize_code(raw)
+    except ValueError:
+        await message.reply("Код должен содержать латиницу, цифры или дефис без пробелов (до 24 символов).")
+        return
+    if len(code) > 24:
+        await message.reply("Максимальная длина кода — 24 символа.")
+        return
+    if promo_repo.get_by_code(code):
+        await message.reply("Такой код уже существует. Введите другой.")
+        return
+    await state.update_data(code=code, normalized=code)
+    await state.set_state(PromoCreateForm.waiting_bonus.state)
+    await message.reply("Введите бонус (целое число > 0).")
+
+
+async def promo_create_bonus(message: types.Message, state: FSMContext):
+    raw = (message.text or "").strip()
+    if raw.lower() in {"/cancel", "отмена"}:
+        await state.finish()
+        await message.reply("Создание промокода отменено.")
+        return
+    if not raw.isdigit() or int(raw) <= 0:
+        await message.reply("Бонус должен быть целым числом больше 0.")
+        return
+    await state.update_data(bonus=int(raw))
+    await state.set_state(PromoCreateForm.waiting_period.state)
+    await message.reply(
+        "Введите период действия: «без срока» или даты в формате YYYY-MM-DD YYYY-MM-DD. "
+        "Можно указать «-» для пропуска начала или конца."
+    )
+
+
+def _parse_period_input(value: str) -> Tuple[Optional[datetime], Optional[datetime]]:
+    cleaned = value.strip().lower()
+    if cleaned in {"", "без срока"}:
+        return None, None
+    parts = value.replace("\u2014", "-").replace("—", "-").split()
+    if len(parts) == 1:
+        start_raw, end_raw = parts[0], parts[0]
+    else:
+        start_raw, end_raw = parts[0], parts[1]
+
+    def _parse(part: str) -> Optional[datetime]:
+        token = part.strip()
+        if not token or token in {"-", "без", "нет"}:
+            return None
+        try:
+            dt = datetime.strptime(token, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError("bad_date") from exc
+        if len(parts) == 1:
+            return datetime(dt.year, dt.month, dt.day, 0, 0, 0)
+        return datetime(dt.year, dt.month, dt.day, 0, 0, 0)
+
+    start = _parse(start_raw)
+    end = _parse(end_raw)
+    if start and end and end < start:
+        raise ValueError("range")
+    if end:
+        end = end.replace(hour=23, minute=59, second=59)
+    return start, end
+
+
+async def promo_create_period(message: types.Message, state: FSMContext):
+    raw = (message.text or "").strip()
+    if raw.lower() in {"/cancel", "отмена"}:
+        await state.finish()
+        await message.reply("Создание промокода отменено.")
+        return
+    try:
+        starts, ends = _parse_period_input(raw)
+    except ValueError:
+        await message.reply(
+            "Не удалось разобрать период. Используйте формат YYYY-MM-DD YYYY-MM-DD или «без срока»."
+        )
+        return
+    await state.update_data(starts_at=starts, expires_at=ends)
+    await state.set_state(PromoCreateForm.waiting_limit.state)
+    await message.reply("Введите лимит активаций (число) или «без лимита».")
+
+
+async def promo_create_limit(message: types.Message, state: FSMContext):
+    raw = (message.text or "").strip()
+    if raw.lower() in {"/cancel", "отмена"}:
+        await state.finish()
+        await message.reply("Создание промокода отменено.")
+        return
+    if raw.lower() in {"без лимита", "без", "нет"}:
+        limit = None
+    else:
+        if not raw.isdigit() or int(raw) <= 0:
+            await message.reply("Лимит должен быть целым числом > 0 или «без лимита».")
+            return
+        limit = int(raw)
+    data = await state.get_data()
+    data.update({"max_redemptions": limit})
+    await state.update_data(max_redemptions=limit)
+    await state.set_state(PromoCreateForm.confirm.state)
+    preview = _build_promo_preview(data)
+    kb = InlineKeyboardMarkup(row_width=2)
+    kb.add(InlineKeyboardButton("Создать", callback_data="admin_promo_create_confirm"))
+    kb.add(InlineKeyboardButton("Отмена", callback_data="admin_promo_create_cancel"))
+    await message.reply(preview, reply_markup=kb, parse_mode="HTML")
+
+
+def _build_promo_preview(data: Dict[str, object]) -> str:
+    code = data.get("code")
+    bonus = data.get("bonus")
+    starts_at = data.get("starts_at")
+    expires_at = data.get("expires_at")
+    limit = data.get("max_redemptions")
+    period = _format_period(starts_at, expires_at)
+    limit_text = "∞" if limit is None else str(limit)
+    return (
+        "🎟 <b>Создание промокода</b>\n"
+        f"Код: <code>{code}</code>\n"
+        f"Бонус: +{bonus} кредитов\n"
+        f"Период: {period}\n"
+        f"Лимит активаций: {limit_text}"
+    )
+
+
+async def cb_promo_create_confirm(call: types.CallbackQuery, state: FSMContext):
+    if not _guard(call.from_user.id):
+        return
+    data = await state.get_data()
+    code = data.get("code")
+    bonus = data.get("bonus")
+    starts_at = data.get("starts_at")
+    expires_at = data.get("expires_at")
+    limit = data.get("max_redemptions")
+    created_by = data.get("created_by", call.from_user.id)
+    if not code or not bonus:
+        await safe_answer(call, "Данные промокода неполные. Начните заново.", show_alert=True)
+        await state.finish()
+        return
+    try:
+        promo_repo.create_code(
+            code=code,
+            normalized_code=code,
+            bonus_credits=int(bonus),
+            title=None,
+            starts_at=starts_at,
+            expires_at=expires_at,
+            max_redemptions=limit,
+            created_by=created_by,
+            meta=None,
+        )
+    except IntegrityError as exc:
+        await safe_answer(call, f"Не удалось создать: {exc}", show_alert=True)
+        return
+    await state.finish()
+    log_event(
+        "promo_created",
+        message="Promo created",
+        code=code,
+        bonus=bonus,
+        limit=limit,
+        starts_at=starts_at.isoformat() if starts_at else None,
+        expires_at=expires_at.isoformat() if expires_at else None,
+        actor=call.from_user.id,
+    )
+    await _safe_edit_text(call.message, _promo_home_text(), reply_markup=_kb_promo_home(), parse_mode="HTML")
+    if not await safe_answer(call, "Промокод создан", show_alert=False):
+        return
+
+
+async def cb_promo_create_cancel(call: types.CallbackQuery, state: FSMContext):
+    if not _guard(call.from_user.id):
+        return
+    await state.finish()
+    await _safe_edit_text(call.message, _promo_home_text(), reply_markup=_kb_promo_home(), parse_mode="HTML")
+    if not await safe_answer(call, "Отменено", show_alert=False):
+        return
+
 # -------- действия: безлимит/кредиты --------
 async def cb_unlim(call: types.CallbackQuery):
     if not _guard(call.from_user.id): return
@@ -423,6 +831,15 @@ def register(dp: Dispatcher):
     dp.register_callback_query_handler(cb_referral_card, lambda c: c.data and c.data.startswith("admin_referral:"))
     dp.register_callback_query_handler(cb_referral_activate, lambda c: c.data and c.data.startswith("admin_referral_activate:"))
     dp.register_callback_query_handler(cb_referral_reject, lambda c: c.data and c.data.startswith("admin_referral_reject:"))
+    dp.register_callback_query_handler(cb_promo_home, lambda c: c.data == "admin_promo")
+    dp.register_callback_query_handler(cb_promo_stats, lambda c: c.data and c.data.startswith("admin_promo_stats:"))
+    dp.register_callback_query_handler(cb_promo_view, lambda c: c.data and c.data.startswith("admin_promo_view:"))
+    dp.register_callback_query_handler(cb_promo_toggle, lambda c: c.data and c.data.startswith("admin_promo_toggle:"))
+    dp.register_callback_query_handler(cb_promo_delete, lambda c: c.data and c.data.startswith("admin_promo_delete:"))
+    dp.register_callback_query_handler(cb_promo_create, lambda c: c.data == "admin_promo_create", state="*")
+    dp.register_callback_query_handler(cb_promo_create_confirm, lambda c: c.data == "admin_promo_create_confirm", state=PromoCreateForm.confirm)
+    dp.register_callback_query_handler(cb_promo_create_cancel, lambda c: c.data == "admin_promo_create_cancel", state="*")
+    dp.register_callback_query_handler(cb_promo_search, lambda c: c.data == "admin_promo_search", state="*")
 
     # рассылки
     dp.register_callback_query_handler(cb_cast_menu,  lambda c: c.data == "admin_cast")
@@ -442,6 +859,11 @@ def register(dp: Dispatcher):
         content_types=types.ContentTypes.TEXT,
     )
     dp.register_message_handler(catch_reply_cast_user,     content_types=types.ContentTypes.TEXT)
+    dp.register_message_handler(promo_search_query, state=PromoSearchForm.waiting_query, content_types=types.ContentTypes.TEXT)
+    dp.register_message_handler(promo_create_code, state=PromoCreateForm.waiting_code, content_types=types.ContentTypes.TEXT)
+    dp.register_message_handler(promo_create_bonus, state=PromoCreateForm.waiting_bonus, content_types=types.ContentTypes.TEXT)
+    dp.register_message_handler(promo_create_period, state=PromoCreateForm.waiting_period, content_types=types.ContentTypes.TEXT)
+    dp.register_message_handler(promo_create_limit, state=PromoCreateForm.waiting_limit, content_types=types.ContentTypes.TEXT)
 
     # команда точечной рассылки
     dp.register_message_handler(cast_cmd, commands=["cast"])

--- a/app/handlers/payments.py
+++ b/app/handlers/payments.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 from aiogram import Dispatcher, types
+from aiogram.dispatcher import FSMContext
+from aiogram.dispatcher.filters.state import State, StatesGroup
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from app import keyboards
 from app.handlers import parse
-from app.services import paywall, payments, referrals
+from app.services import paywall, payments, referrals, promo
 from app.utils.callbacks import safe_answer
 from app.utils.logging import complete_operation, log_event, update_context
 from app.utils.admins import is_admin
+
+
+class PromoForm(StatesGroup):
+    waiting_code = State()
 
 
 def _resolve_pack(data: str) -> str | None:
@@ -98,6 +104,15 @@ async def cb_buy_back(call: types.CallbackQuery):
     )
 
 
+async def cb_buy_promo(call: types.CallbackQuery, state: FSMContext):
+    update_context(command="buy_promo")
+    log_event("promo_redeem_prompt", message="Promo prompt opened")
+    if not await safe_answer(call):
+        return
+    await state.set_state(PromoForm.waiting_code.state)
+    await call.message.answer("Введите промокод одним сообщением (без пробелов).")
+
+
 async def cb_check(call: types.CallbackQuery):
     pid = call.data.split(":", 1)[1]
     update_context(command="pay_check", args={"payment_id": pid})
@@ -116,6 +131,24 @@ async def cb_check(call: types.CallbackQuery):
     if status == "succeeded":
         await parse.prompt_resume(call.bot, call.from_user.id)
     await safe_answer(call)
+
+
+async def promo_code_entered(message: types.Message, state: FSMContext):
+    text = (message.text or "").strip()
+    if text.lower() in {"/cancel", "отмена"}:
+        await state.finish()
+        await message.reply(
+            "Отменено.",
+            reply_markup=keyboards.main_kb(is_admin=is_admin(message.from_user.id)),
+        )
+        return
+
+    update_context(command="promo_redeem", args={"raw": text})
+    log_event("promo_redeem_request", message="Promo redeem requested", raw=text)
+    result = promo.redeem_promo(message.from_user.id, text)
+    reply_kb = keyboards.promo_result_kb()
+    await message.reply(result.message, reply_markup=reply_kb)
+    await state.finish()
 
 
 async def start_with_payload(message: types.Message):
@@ -172,7 +205,11 @@ def _format_user_mention(user: types.User | None) -> str:
 
 def register(dp: Dispatcher):
     dp.register_message_handler(cmd_buy, commands=["buy"])
-    dp.register_message_handler(cmd_buy, lambda m: m.text in {"💳 Купить", "Купить"}, state="*")
+    dp.register_message_handler(
+        cmd_buy,
+        lambda m: (m.text or "").strip() in {"💳 Купить", "Купить", "Купить ещё кредиты"},
+        state="*",
+    )
     dp.register_callback_query_handler(cb_buy_open, lambda c: c.data == "buy:open", state="*")
     dp.register_callback_query_handler(cb_buy_info, lambda c: c.data == "buy:info", state="*")
     dp.register_callback_query_handler(cb_buy_back, lambda c: c.data == "buy:back", state="*")
@@ -181,6 +218,8 @@ def register(dp: Dispatcher):
         lambda c: c.data and (c.data.startswith("buy:pack:") or c.data.startswith("buy:unlim:")),
         state="*",
     )
+    dp.register_callback_query_handler(cb_buy_promo, lambda c: c.data == "buy:promo", state="*")
     dp.register_callback_query_handler(cb_create, lambda c: c.data and c.data.startswith("pay_create:"))
     dp.register_callback_query_handler(cb_check, lambda c: c.data and c.data.startswith("pay_check:"))
     dp.register_message_handler(start_with_payload, commands=["start"])
+    dp.register_message_handler(promo_code_entered, state=PromoForm.waiting_code, content_types=types.ContentTypes.TEXT)

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -8,3 +8,9 @@ def main_kb(is_admin: bool = False) -> ReplyKeyboardMarkup:
     if is_admin:
         kb.add(KeyboardButton("🛠 Админ"))
     return kb
+
+
+def promo_result_kb() -> ReplyKeyboardMarkup:
+    kb = ReplyKeyboardMarkup(resize_keyboard=True)
+    kb.row(KeyboardButton("🔎 Поиск"), KeyboardButton("Купить ещё кредиты"))
+    return kb

--- a/app/services/paywall.py
+++ b/app/services/paywall.py
@@ -154,6 +154,7 @@ def paywall_keyboard() -> InlineKeyboardMarkup:
         price_text = pack_price_text(pack_id)
         button_text = f"{title} — {price_text}" if price_text else title
         kb.add(InlineKeyboardButton(button_text, callback_data=callback_data))
+    kb.add(InlineKeyboardButton("🎟️ У меня есть промокод", callback_data="buy:promo"))
     return kb
 
 

--- a/app/services/promo.py
+++ b/app/services/promo.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from peewee import IntegrityError
+
+from app.storage import promo_repo, referrals_repo, repo
+from app.storage.db import db
+from app.storage.models import PromoCreditCode
+from app.utils.logging import log_event, update_context
+
+_CODE_RE = re.compile(r"^[A-Z0-9-]{1,64}$")
+
+
+@dataclass
+class PromoRedeemResult:
+    ok: bool
+    message: str
+    new_balance: Optional[int]
+    code: Optional[str] = None
+    bonus: Optional[int] = None
+    reason: Optional[str] = None
+
+
+def normalize_code(raw: str) -> str:
+    value = (raw or "").strip()
+    if not value or any(ch.isspace() for ch in value):
+        raise ValueError("empty")
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError("non_ascii") from exc
+    value = value.upper()
+    if not _CODE_RE.fullmatch(value):
+        raise ValueError("bad_format")
+    return value
+
+
+def _promo_invalid(message: str, *, reason: str, code: str | None, raw: str) -> PromoRedeemResult:
+    log_event(
+        "promo_redeem_failed",
+        message=message,
+        reason=reason,
+        code=code,
+        raw_code=raw,
+    )
+    update_context(err=reason)
+    return PromoRedeemResult(False, message, None, code=code, reason=reason)
+
+
+def redeem_promo(user_id: int, raw_code: str) -> PromoRedeemResult:
+    try:
+        normalized = normalize_code(raw_code)
+    except ValueError:
+        return _promo_invalid("⚠️ Промокод указан неверно.", reason="invalid_format", code=None, raw=raw_code)
+
+    promo: PromoCreditCode | None = promo_repo.get_by_normalized_code(normalized)
+    now = datetime.utcnow()
+    if not promo or not promo.is_active:
+        return _promo_invalid(
+            "⚠️ Промокод недействителен или срок действия истёк.",
+            reason="not_found",
+            code=normalized,
+            raw=raw_code,
+        )
+    if promo.starts_at and now < promo.starts_at:
+        return _promo_invalid(
+            "⚠️ Промокод недействителен или срок действия истёк.",
+            reason="not_started",
+            code=promo.code,
+            raw=raw_code,
+        )
+    if promo.expires_at and now > promo.expires_at:
+        return _promo_invalid(
+            "⚠️ Промокод недействителен или срок действия истёк.",
+            reason="expired",
+            code=promo.code,
+            raw=raw_code,
+        )
+
+    if promo_repo.user_has_redeemed(user_id, promo.code):
+        log_event(
+            "promo_redeem_duplicate",
+            message="Promo already redeemed",
+            code=promo.code,
+            user_id=user_id,
+        )
+        return PromoRedeemResult(False, "ℹ️ Этот промокод уже был активирован на ваш аккаунт.", None, code=promo.code, reason="already_redeemed")
+
+    if promo.max_redemptions is not None and promo.redemptions_count >= promo.max_redemptions:
+        return _promo_invalid(
+            "⚠️ Лимит активаций по этому промокоду исчерпан.",
+            reason="limit_reached",
+            code=promo.code,
+            raw=raw_code,
+        )
+
+    operation_id = f"promo:{promo.code}:{user_id}"
+
+    try:
+        with db.atomic():
+            if promo_repo.user_has_redeemed(user_id, promo.code):
+                log_event(
+                    "promo_redeem_duplicate",
+                    message="Promo already redeemed (tx)",
+                    code=promo.code,
+                    user_id=user_id,
+                )
+                return PromoRedeemResult(False, "ℹ️ Этот промокод уже был активирован на ваш аккаунт.", None, code=promo.code, reason="already_redeemed")
+            if not promo_repo.reserve_redemption_slot(promo):
+                return _promo_invalid(
+                    "⚠️ Лимит активаций по этому промокоду исчерпан.",
+                    reason="limit_reached",
+                    code=promo.code,
+                    raw=raw_code,
+                )
+            promo_repo.create_redemption(user_id, promo, operation_id)
+            update_context(args={"promo_code": promo.code})
+            repo.ensure_user(user_id, None, None)
+            new_balance = referrals_repo.grant_credit(
+                user_id,
+                promo.bonus_credits,
+                "promo_code",
+                operation_id=operation_id,
+            )
+    except IntegrityError as exc:
+        log_event(
+            "promo_redeem_failed",
+            level="ERROR",
+            message="Integrity error during redemption",
+            code=promo.code if promo else normalized,
+            err=str(exc),
+        )
+        return PromoRedeemResult(False, "⚠️ Не удалось применить промокод. Попробуйте позже.", None, code=promo.code if promo else normalized, reason="db_error")
+    except Exception as exc:  # pragma: no cover - defensive
+        log_event(
+            "promo_redeem_failed",
+            level="ERROR",
+            message="Unexpected error during redemption",
+            code=promo.code if promo else normalized,
+            err=str(exc),
+        )
+        return PromoRedeemResult(False, "⚠️ Не удалось применить промокод. Попробуйте позже.", None, code=promo.code if promo else normalized, reason="unexpected")
+
+    update_context(credits_delta=promo.bonus_credits)
+    log_event(
+        "promo_redeem_success",
+        message="Promo applied",
+        code=promo.code,
+        bonus=promo.bonus_credits,
+        user_id=user_id,
+        new_balance=new_balance,
+    )
+    text = (
+        f"✅ Промокод {promo.code} активирован: +{promo.bonus_credits} кредитов. "
+        f"Ваш баланс: {new_balance}."
+    )
+    return PromoRedeemResult(True, text, new_balance, code=promo.code, bonus=promo.bonus_credits)

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -78,6 +78,8 @@ def init_db() -> None:
         Ledger,
         ReferralBan,
         SearchQuery,
+        PromoCreditCode,
+        PromoRedemption,
     )  # noqa: WPS347
     db.connect(reuse_if_open=True)
     db.create_tables([
@@ -91,5 +93,15 @@ def init_db() -> None:
         Ledger,
         ReferralBan,
         SearchQuery,
-    ])
+        PromoCreditCode,
+        PromoRedemption,
+    ], safe=True)
+
+    ledger_columns = {col.name for col in db.get_columns("ledger")}
+    if "operation_id" not in ledger_columns:
+        db.execute_sql("ALTER TABLE ledger ADD COLUMN operation_id TEXT")
+    db.execute_sql(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_ledger_operation_id "
+        "ON ledger(operation_id) WHERE operation_id IS NOT NULL"
+    )
     db.close()

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -95,6 +95,7 @@ class Ledger(BaseModel):
     related_referral = ForeignKeyField(Referral, null=True, on_delete="SET NULL")
     ts = DateTimeField(default=datetime.utcnow)
     balance_after = IntegerField(null=True)
+    operation_id = CharField(null=True, unique=True)
 
 
 class ReferralBan(BaseModel):
@@ -110,3 +111,41 @@ class SearchQuery(BaseModel):
     role = CharField()
     city = CharField()
     created_at = DateTimeField(default=datetime.utcnow, index=True)
+
+
+class PromoCreditCode(BaseModel):
+    code = CharField(primary_key=True, max_length=64)
+    normalized_code = CharField(unique=True, max_length=64)
+    title = CharField(null=True)
+    bonus_credits = IntegerField()
+    is_active = BooleanField(default=True)
+    starts_at = DateTimeField(null=True)
+    expires_at = DateTimeField(null=True)
+    max_redemptions = IntegerField(null=True)
+    redemptions_count = IntegerField(default=0)
+    created_at = DateTimeField(default=datetime.utcnow)
+    created_by = BigIntegerField()
+    meta = TextField(null=True)
+
+    class Meta:
+        table_name = "promo_codes"
+
+
+class PromoRedemption(BaseModel):
+    id = AutoField()
+    user = ForeignKeyField(User, backref="promo_redemptions", on_delete="CASCADE")
+    promo_code = ForeignKeyField(
+        PromoCreditCode,
+        backref="redemptions",
+        field=PromoCreditCode.code,
+        on_delete="CASCADE",
+        column_name="code",
+    )
+    created_at = DateTimeField(default=datetime.utcnow)
+    operation_id = CharField(unique=True)
+
+    class Meta:
+        table_name = "promo_redemptions"
+        indexes = (
+            (("user", "promo_code"), True),
+        )

--- a/app/storage/promo_repo.py
+++ b/app/storage/promo_repo.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, Optional, Sequence
+
+from peewee import fn
+
+from .db import db
+from .models import PromoCreditCode, PromoRedemption, User
+
+
+def get_by_normalized_code(code: str) -> Optional[PromoCreditCode]:
+    return PromoCreditCode.get_or_none(PromoCreditCode.normalized_code == code)
+
+
+def get_by_code(code: str) -> Optional[PromoCreditCode]:
+    return PromoCreditCode.get_or_none(PromoCreditCode.code == code)
+
+
+def create_code(
+    *,
+    code: str,
+    normalized_code: str,
+    bonus_credits: int,
+    title: str | None,
+    starts_at: datetime | None,
+    expires_at: datetime | None,
+    max_redemptions: int | None,
+    created_by: int,
+    meta: str | None = None,
+) -> PromoCreditCode:
+    with db.atomic():
+        return PromoCreditCode.create(
+            code=code,
+            normalized_code=normalized_code,
+            title=title,
+            bonus_credits=bonus_credits,
+            is_active=True,
+            starts_at=starts_at,
+            expires_at=expires_at,
+            max_redemptions=max_redemptions,
+            created_by=created_by,
+            meta=meta,
+        )
+
+
+def list_codes(*, offset: int = 0, limit: int = 20, search: str | None = None) -> Sequence[PromoCreditCode]:
+    query = PromoCreditCode.select().order_by(PromoCreditCode.created_at.desc())
+    if search:
+        needle = search.strip().upper()
+        query = query.where(
+            (PromoCreditCode.code.contains(needle))
+            | (PromoCreditCode.normalized_code.contains(needle))
+        )
+        query = query.order_by(PromoCreditCode.code.asc())
+    return list(query.offset(max(0, offset)).limit(max(0, limit)))
+
+
+def count_codes(search: str | None = None) -> int:
+    query = PromoCreditCode.select()
+    if search:
+        needle = search.strip().upper()
+        query = query.where(
+            (PromoCreditCode.code.contains(needle))
+            | (PromoCreditCode.normalized_code.contains(needle))
+        )
+    return query.count()
+
+
+def set_active(code: str, is_active: bool) -> bool:
+    return bool(
+        PromoCreditCode.update(is_active=is_active)
+        .where(PromoCreditCode.code == code)
+        .execute()
+    )
+
+
+def delete_code(code: str) -> bool:
+    with db.atomic():
+        promo = PromoCreditCode.get_or_none(PromoCreditCode.code == code)
+        if not promo:
+            return False
+        if PromoRedemption.select().where(PromoRedemption.promo_code == code).exists():
+            return False
+        promo.delete_instance()
+        return True
+
+
+def user_has_redeemed(user_id: int, code: str) -> bool:
+    return PromoRedemption.select().where(
+        (PromoRedemption.user == user_id) & (PromoRedemption.promo_code == code)
+    ).exists()
+
+
+def reserve_redemption_slot(promo: PromoCreditCode) -> bool:
+    update = (
+        PromoCreditCode.update(redemptions_count=PromoCreditCode.redemptions_count + 1)
+        .where(
+            (PromoCreditCode.code == promo.code)
+            & (
+                (PromoCreditCode.max_redemptions.is_null())
+                | (PromoCreditCode.redemptions_count < PromoCreditCode.max_redemptions)
+            )
+        )
+        .execute()
+    )
+    if update:
+        promo.redemptions_count += 1
+    return bool(update)
+
+
+def create_redemption(user_id: int, promo: PromoCreditCode, operation_id: str) -> PromoRedemption:
+    User.get_or_create(user_id=user_id)
+    return PromoRedemption.create(user=user_id, promo_code=promo.code, operation_id=operation_id)
+
+
+def redemption_counts(promo: PromoCreditCode) -> dict[str, int]:
+    now = datetime.utcnow()
+    total = (
+        PromoRedemption.select(fn.COUNT(PromoRedemption.id))
+        .where(PromoRedemption.promo_code == promo.code)
+        .scalar()
+        or 0
+    )
+    last7 = (
+        PromoRedemption.select(fn.COUNT(PromoRedemption.id))
+        .where(
+            (PromoRedemption.promo_code == promo.code)
+            & (PromoRedemption.created_at >= now - timedelta(days=7))
+        )
+        .scalar()
+        or 0
+    )
+    last30 = (
+        PromoRedemption.select(fn.COUNT(PromoRedemption.id))
+        .where(
+            (PromoRedemption.promo_code == promo.code)
+            & (PromoRedemption.created_at >= now - timedelta(days=30))
+        )
+        .scalar()
+        or 0
+    )
+    return {"total": total, "last7": last7, "last30": last30}
+
+
+def paginated_stats(*, limit: int = 10, offset: int = 0) -> Iterable[PromoCreditCode]:
+    return (
+        PromoCreditCode.select()
+        .order_by(PromoCreditCode.created_at.desc())
+        .offset(max(0, offset))
+        .limit(max(0, limit))
+    )
+
+
+def search_codes(query: str, *, limit: int = 20) -> Sequence[PromoCreditCode]:
+    if not query:
+        return []
+    token = query.strip().upper()
+    return list(
+        PromoCreditCode.select()
+        .where(
+            (PromoCreditCode.code.contains(token))
+            | (PromoCreditCode.normalized_code.contains(token))
+        )
+        .order_by(PromoCreditCode.code.asc())
+        .limit(max(1, limit))
+    )

--- a/app/storage/referrals_repo.py
+++ b/app/storage/referrals_repo.py
@@ -138,12 +138,22 @@ def increment_bonuses(inviter_id: int, delta: int) -> None:
     ).where(ReferralStats.user == inviter_id).execute()
 
 
-def grant_credit(user_id: int, delta: int, reason: str, referral: Optional[Referral] = None) -> int:
+def grant_credit(
+    user_id: int,
+    delta: int,
+    reason: str,
+    referral: Optional[Referral] = None,
+    operation_id: str | None = None,
+) -> int:
     from . import repo
 
     with db.atomic():
         repo.ensure_user(user_id, None, None)
         credit, _ = Credit.get_or_create(user=user_id, defaults={"balance": 0})
+        if operation_id:
+            ledger_entry = Ledger.get_or_none(Ledger.operation_id == operation_id)
+            if ledger_entry:
+                return ledger_entry.balance_after or credit.balance
         new_balance = max(0, credit.balance + delta)
         Credit.update(balance=new_balance).where(Credit.id == credit.id).execute()
         Ledger.create(
@@ -153,6 +163,7 @@ def grant_credit(user_id: int, delta: int, reason: str, referral: Optional[Refer
             reason=reason,
             related_referral=referral,
             balance_after=new_balance,
+            operation_id=operation_id,
         )
         return new_balance
 

--- a/tests/test_promo.py
+++ b/tests/test_promo.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("peewee")
+
+
+@pytest.fixture()
+def promo_env(monkeypatch, tmp_path):
+    db_path = tmp_path / "promo.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    from app.storage import db as db_module
+
+    importlib.reload(db_module)
+    from app.storage import models
+    importlib.reload(models)
+    from app.storage import repo
+    importlib.reload(repo)
+    from app.storage import referrals_repo
+    importlib.reload(referrals_repo)
+    from app.storage import promo_repo
+    importlib.reload(promo_repo)
+    from app.services import promo as promo_service
+    importlib.reload(promo_service)
+
+    db_module.init_db()
+
+    yield {
+        "db": db_module,
+        "models": models,
+        "repo": repo,
+        "referrals_repo": referrals_repo,
+        "promo_repo": promo_repo,
+        "promo_service": promo_service,
+    }
+
+    db_module.db.close()
+
+
+def test_redeem_promo_success(promo_env):
+    promo_repo = promo_env["promo_repo"]
+    promo_service = promo_env["promo_service"]
+    now = datetime.utcnow()
+    promo_repo.create_code(
+        code="TESTCODE",
+        normalized_code="TESTCODE",
+        bonus_credits=5,
+        title=None,
+        starts_at=now - timedelta(days=1),
+        expires_at=now + timedelta(days=1),
+        max_redemptions=None,
+        created_by=123,
+        meta=None,
+    )
+
+    result = promo_service.redeem_promo(1, "testcode")
+    assert result.ok
+    assert "✅ Промокод TESTCODE активирован" in result.message
+    assert result.new_balance == 5
+
+    repeat = promo_service.redeem_promo(1, "TESTCODE")
+    assert not repeat.ok
+    assert "уже был активирован" in repeat.message
+
+
+def test_redeem_promo_limit_and_inactive(promo_env):
+    promo_repo = promo_env["promo_repo"]
+    promo_service = promo_env["promo_service"]
+    now = datetime.utcnow()
+    promo_repo.create_code(
+        code="LIMIT1",
+        normalized_code="LIMIT1",
+        bonus_credits=2,
+        title=None,
+        starts_at=now - timedelta(days=1),
+        expires_at=now + timedelta(days=1),
+        max_redemptions=1,
+        created_by=123,
+        meta=None,
+    )
+
+    assert promo_service.redeem_promo(10, "LIMIT1").ok
+    limited = promo_service.redeem_promo(11, "LIMIT1")
+    assert not limited.ok
+    assert "Лимит" in limited.message
+
+    promo_repo.set_active("LIMIT1", False)
+    inactive = promo_service.redeem_promo(12, "LIMIT1")
+    assert not inactive.ok
+    assert "недействителен" in inactive.message
+
+
+def test_redeem_promo_invalid_and_expired(promo_env):
+    promo_repo = promo_env["promo_repo"]
+    promo_service = promo_env["promo_service"]
+    now = datetime.utcnow()
+    promo_repo.create_code(
+        code="EXPIRE",
+        normalized_code="EXPIRE",
+        bonus_credits=3,
+        title=None,
+        starts_at=now - timedelta(days=3),
+        expires_at=now - timedelta(days=1),
+        max_redemptions=None,
+        created_by=321,
+        meta=None,
+    )
+
+    invalid = promo_service.redeem_promo(50, "bad code")
+    assert not invalid.ok
+    assert "указан неверно" in invalid.message
+
+    expired = promo_service.redeem_promo(51, "EXPIRE")
+    assert not expired.ok
+    assert "недействителен" in expired.message


### PR DESCRIPTION
## Summary
- add database entities and service logic for promo code redemptions with idempotent ledger writes
- extend the payment flow with manual promo entry and quick access buttons
- implement an admin UI to create, toggle, delete, and search promo codes with basic analytics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d67ed6fedc8320970add658994705a