### PR TITLE
Fix missing buttons in admin and payment menus

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -27,12 +27,14 @@ PAGE_SIZE = 10
 
 def _kb_admin_home() -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup(row_width=2)
-    kb.add(
+    kb.row(
         InlineKeyboardButton("👥 Пользователи", callback_data="admin_users:1"),
         InlineKeyboardButton("📣 Рассылка", callback_data="admin_cast"),
     )
-    kb.add(InlineKeyboardButton("🎯 Рефералы", callback_data="admin_ref"))
-    kb.add(InlineKeyboardButton("🎟 Промокоды", callback_data="admin_promo"))
+    kb.row(
+        InlineKeyboardButton("🎯 Рефералы", callback_data="admin_ref"),
+        InlineKeyboardButton("🎟 Промокоды", callback_data="admin_promo"),
+    )
     kb.add(InlineKeyboardButton("💾 Бэкап БД", callback_data="admin_backup"))
     return kb
 

--- a/app/services/paywall.py
+++ b/app/services/paywall.py
@@ -155,6 +155,10 @@ def paywall_keyboard() -> InlineKeyboardMarkup:
         button_text = f"{title} — {price_text}" if price_text else title
         kb.add(InlineKeyboardButton(button_text, callback_data=callback_data))
     kb.add(InlineKeyboardButton("🎟️ У меня есть промокод", callback_data="buy:promo"))
+    kb.row(
+        InlineKeyboardButton("ℹ️ Подробнее", callback_data="buy:info"),
+        InlineKeyboardButton("⬅️ В меню", callback_data="buy:back"),
+    )
     return kb
 
 


### PR DESCRIPTION
## Summary
- ensure the admin home keyboard lays out the promo button explicitly so it appears in the panel
- add info and back buttons to the payment keyboard to expose the related handlers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d684be68c88320b2e976e36e69f7cf