### PR TITLE
Fix promo credit stacking

### DIFF
--- a/app/storage/referrals_repo.py
+++ b/app/storage/referrals_repo.py
@@ -150,11 +150,17 @@ def grant_credit(
     with db.atomic():
         repo.ensure_user(user_id, None, None)
         credit, _ = Credit.get_or_create(user=user_id, defaults={"balance": 0})
+        current_balance = (
+            Credit.select(Credit.balance)
+            .where(Credit.id == credit.id)
+            .scalar()
+            or 0
+        )
         if operation_id:
             ledger_entry = Ledger.get_or_none(Ledger.operation_id == operation_id)
             if ledger_entry:
-                return ledger_entry.balance_after or credit.balance
-        new_balance = max(0, credit.balance + delta)
+                return ledger_entry.balance_after or current_balance
+        new_balance = max(0, current_balance + delta)
         Credit.update(balance=new_balance).where(Credit.id == credit.id).execute()
         Ledger.create(
             user=user_id,

--- a/tests/test_promo.py
+++ b/tests/test_promo.py
@@ -117,3 +117,36 @@ def test_redeem_promo_invalid_and_expired(promo_env):
     expired = promo_service.redeem_promo(51, "EXPIRE")
     assert not expired.ok
     assert "недействителен" in expired.message
+
+
+def test_redeem_promo_preserves_existing_balance(promo_env):
+    repo = promo_env["repo"]
+    promo_repo = promo_env["promo_repo"]
+    promo_service = promo_env["promo_service"]
+    user_id = 123
+    now = datetime.utcnow()
+    promo_repo.create_code(
+        code="STACKUP",
+        normalized_code="STACKUP",
+        bonus_credits=5,
+        title=None,
+        starts_at=now - timedelta(days=1),
+        expires_at=now + timedelta(days=1),
+        max_redemptions=None,
+        created_by=999,
+        meta=None,
+    )
+
+    repo.ensure_user(user_id, "tester", "Test User")
+    repo.add_credits(user_id, 15)
+    repo.set_unlimited(user_id, 30)
+
+    result = promo_service.redeem_promo(user_id, "STACKUP")
+
+    assert result.ok
+    assert result.new_balance == 20
+    assert repo.get_credits(user_id) == 20
+
+    active, until = repo.is_unlimited_active(user_id)
+    assert active
+    assert until is not None


### PR DESCRIPTION
## Summary
- ensure promo credit grants read the latest balance before applying a bonus to avoid clobbering existing credits
- add regression coverage proving promo bonuses keep paid credits and the unlimited plan intact

## Testing
- pytest tests/test_promo.py

------
https://chatgpt.com/codex/tasks/task_e_68d6895ac69483209976eaf1d213c01f