### PR TITLE
Fix paywall menu buttons and promo credit balance

### DIFF
--- a/app/services/paywall.py
+++ b/app/services/paywall.py
@@ -155,10 +155,6 @@ def paywall_keyboard() -> InlineKeyboardMarkup:
         button_text = f"{title} — {price_text}" if price_text else title
         kb.add(InlineKeyboardButton(button_text, callback_data=callback_data))
     kb.add(InlineKeyboardButton("🎟️ У меня есть промокод", callback_data="buy:promo"))
-    kb.row(
-        InlineKeyboardButton("ℹ️ Подробнее", callback_data="buy:info"),
-        InlineKeyboardButton("⬅️ В меню", callback_data="buy:back"),
-    )
     return kb
 
 

--- a/app/storage/referrals_repo.py
+++ b/app/storage/referrals_repo.py
@@ -149,10 +149,10 @@ def grant_credit(
 
     with db.atomic():
         repo.ensure_user(user_id, None, None)
-        credit, _ = Credit.get_or_create(user=user_id, defaults={"balance": 0})
+        _credit, _ = Credit.get_or_create(user=user_id, defaults={"balance": 0})
         current_balance = (
             Credit.select(Credit.balance)
-            .where(Credit.id == credit.id)
+            .where(Credit.user == user_id)
             .scalar()
             or 0
         )
@@ -161,7 +161,7 @@ def grant_credit(
             if ledger_entry:
                 return ledger_entry.balance_after or current_balance
         new_balance = max(0, current_balance + delta)
-        Credit.update(balance=new_balance).where(Credit.id == credit.id).execute()
+        Credit.update(balance=new_balance).where(Credit.user == user_id).execute()
         Ledger.create(
             user=user_id,
             kind="credit",


### PR DESCRIPTION
## Summary
- remove the info/back buttons from the paywall keyboard so they no longer appear in the payment menu
- ensure promo credit grants update balances by user id so existing credits are preserved when redeeming a code

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68e49cee88320a773d84771c4b103