### PR TITLE
Handle NaN schedule values when computing workdays

### DIFF
--- a/tests/test_build_job_analytics.py
+++ b/tests/test_build_job_analytics.py
@@ -1,0 +1,26 @@
+import math
+from pathlib import Path
+import sys
+import types
+
+fake_pd = types.SimpleNamespace(
+    isna=lambda value: isinstance(value, float) and math.isnan(value),
+    DataFrame=object,
+    Series=object,
+    ExcelWriter=object,
+)
+sys.modules.setdefault("pandas", fake_pd)
+fake_np = types.SimpleNamespace(nan=float("nan"))
+sys.modules.setdefault("numpy", fake_np)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from vendor.parser_tdnm.build_job_analytics import _workdays_per_month
+
+
+def test_workdays_handles_nan_like_values():
+    assert _workdays_per_month(None) is None
+    assert _workdays_per_month(math.nan) is None
+    assert _workdays_per_month(float("nan")) is None
+    # Non-schedule numeric value should not crash and should return None
+    assert _workdays_per_month(0) is None

--- a/vendor/parser_tdnm/build_job_analytics.py
+++ b/vendor/parser_tdnm/build_job_analytics.py
@@ -82,7 +82,14 @@ def _parse_shift_len_value(val):
     return None
 
 def _workdays_per_month(schedule_str: str):
-    g=(schedule_str or "").lower()
+    if schedule_str is None:
+        return None
+    try:
+        if pd.isna(schedule_str):
+            return None
+    except TypeError:
+        pass
+    g = str(schedule_str).lower()
     if "5/2" in g: return 21.0
     if "6/1" in g: return 26.0
     m=re.search(r"\b([1-7])\s*[/\-–]\s*([1-7])\b", g)


### PR DESCRIPTION
## Summary
- guard the workdays-per-month helper against missing or NaN schedule values so analytics parsing does not crash
- add a regression test that covers NaN-like schedule inputs without requiring the pandas dependency at test time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da41f2c0e483208547470c567a75f4